### PR TITLE
Add loop method to \Zend\View\Helper\PartialLoop

### DIFF
--- a/src/Helper/PartialLoop.php
+++ b/src/Helper/PartialLoop.php
@@ -58,7 +58,20 @@ class PartialLoop extends Partial
         if (0 == func_num_args()) {
             return $this;
         }
+        return $this->loop($name, $values);
+    }
 
+    /**
+     * Renders a template fragment within a variable scope distinct from the
+     * calling View object.
+     *
+     * @param  string $name   Name of view script
+     * @param  array  $values Variables to populate in the view
+     * @throws Exception\InvalidArgumentException
+     * @return string
+     */
+    public function loop($name = null, $values = null)
+    {
         // reset the counter if it's called again
         $this->partialCounter = 0;
         $content = '';


### PR DESCRIPTION
Allows to chain setter with rendering, for example :

```
<?= $this->partialLoop()
    ->setObjectKey('myKey')
    ->loop('myPartial', $myArray) ?>
```
An alternative could be a 3rd parameter to invoke for the key.