### PR TITLE
Use the Host port when port forwarding is detected

### DIFF
--- a/src/Helper/ServerUrl.php
+++ b/src/Helper/ServerUrl.php
@@ -79,22 +79,23 @@ class ServerUrl extends AbstractHelper
 
         if (isset($_SERVER['HTTP_HOST']) && !empty($_SERVER['HTTP_HOST'])) {
             // Detect if the port is set in SERVER_PORT and included in HTTP_HOST
-            if (isset($_SERVER['SERVER_PORT'])) {
-                $portStr = ':' . $_SERVER['SERVER_PORT'];
-                if (substr($_SERVER['HTTP_HOST'], 0-strlen($portStr), strlen($portStr)) == $portStr) {
-                    $this->setHost(substr($_SERVER['HTTP_HOST'], 0, 0-strlen($portStr)));
+            if (isset($_SERVER['SERVER_PORT'])
+                && preg_match('/^(?P<host>.*?):(?P<port>\d+)$/', $_SERVER['HTTP_HOST'], $matches)
+            ) {
+                // If they are the same, set the host to just the hostname
+                // portion of the Host header.
+                if ((int) $matches['port'] === (int) $_SERVER['SERVER_PORT']) {
+                    $this->setHost($matches['host']);
                     return;
                 }
 
-                // If the Host header contains a port, and it differs from the
-                // SERVER_PORT, use the port from the Host header. Typically
-                // this is a situation where port-forwarding is in use, and you
-                // want to present a URI using the public port.
-                if (preg_match('/^(?P<host>.*?):(?P<port>\d+)$/', $_SERVER['HTTP_HOST'], $matches)) {
-                    $this->setPort((int) $matches['port']);
-                    $this->setHost(rtrim($matches['host']));
-                    return;
-                }
+                // At this point, we have a SERVER_PORT that differs from the
+                // Host header, indicating we likely have a port-forwarding
+                // situation. As such, we'll set the host and port from the
+                // matched values.
+                $this->setPort((int) $matches['port']);
+                $this->setHost($matches['host']);
+                return;
             }
 
             $this->setHost($_SERVER['HTTP_HOST']);

--- a/src/Helper/ServerUrl.php
+++ b/src/Helper/ServerUrl.php
@@ -85,6 +85,16 @@ class ServerUrl extends AbstractHelper
                     $this->setHost(substr($_SERVER['HTTP_HOST'], 0, 0-strlen($portStr)));
                     return;
                 }
+
+                // If the Host header contains a port, and it differs from the
+                // SERVER_PORT, use the port from the Host header. Typically
+                // this is a situation where port-forwarding is in use, and you
+                // want to present a URI using the public port.
+                if (preg_match('/^(?P<host>.*?):(?P<port>\d+)$/', $_SERVER['HTTP_HOST'], $matches)) {
+                    $this->setPort((int) $matches['port']);
+                    $this->setHost(rtrim($matches['host']));
+                    return;
+                }
             }
 
             $this->setHost($_SERVER['HTTP_HOST']);

--- a/test/Helper/ServerUrlTest.php
+++ b/test/Helper/ServerUrlTest.php
@@ -219,4 +219,12 @@ class ServerUrlTest extends \PHPUnit_Framework_TestCase
         $url->setUseProxy(true);
         $this->assertEquals('http://www.secondhost.org:8888', $url->__invoke());
     }
+
+    public function testUsesHostHeaderWhenPortForwardingDetected()
+    {
+        $_SERVER['HTTP_HOST'] = 'localhost:10088';
+        $_SERVER['SERVER_PORT'] = 10081;
+        $url = new Helper\ServerUrl();
+        $this->assertEquals('http://localhost:10088', $url->__invoke());
+    }
 }


### PR DESCRIPTION
In vagrant and other systems, you often have a port on the host forwarding to a port on the client box. In terms of ServerUrl, the port on the host server is the public one that should be used.

Prior to this patch ServerUrl was detecting both the port from the Host header, as well as SERVER_PORT, and using *both* in generated URLs.

As an example, given:

- HTTP_HOST: localhost:10088
- SERVER_PORT: 10081

ServerUrl would generate the host "localhost:10088:10081", when it should be generating "localhost:10088". This patch corrects the situation.