### PR TITLE
Added itemprop to allowed attributes

### DIFF
--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -46,7 +46,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         'sizes',
         'type',
         'title',
-        'extras'
+        'extras',
+        'itemprop'
     ];
 
     /**

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -445,4 +445,10 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
         $this->helper->appendStylesheet(['rel' => 'icon', 'href' => '/bar/baz', 'sizes' => '123x456']);
         $this->assertContains('sizes="123x456"', $this->helper->toString());
     }
+    
+    public function testItempropAttributeIsSupported()
+    {
+        $this->helper->prependAlternate(['itemprop' => 'url', 'href' => '/bar/baz', 'rel' => 'canonical']);
+        $this->assertContains('itemprop="url"', $this->helper->toString());
+    }
 }


### PR DESCRIPTION
Allows to set something like the following. Is needed for setting structured data markup.
[Include Your Site Name in Search Results](https://developers.google.com/structured-data/site-name).

```php
$this->headLink()->prependAlternate(
    [
        'rel' => 'canonical',
        'itemprop' => 'url',
        'href' => 'https://example.com/'
    ],
    'APPEND'
);
```
```
<link rel="canonical" href="https://example.com/" itemprop="url">
```