### PR TITLE
remove deprecated const EOL = PHP_EOL; in AbstractHtmlElement

### DIFF
--- a/src/Helper/AbstractHtmlElement.php
+++ b/src/Helper/AbstractHtmlElement.php
@@ -12,13 +12,6 @@ namespace Zend\View\Helper;
 abstract class AbstractHtmlElement extends AbstractHelper
 {
     /**
-     * EOL character
-     *
-     * @deprecated just use PHP_EOL
-     */
-    const EOL = PHP_EOL;
-
-    /**
      * The tag closing bracket
      *
      * @var string

--- a/test/Helper/HtmlListTest.php
+++ b/test/Helper/HtmlListTest.php
@@ -108,11 +108,11 @@ class HtmlListTest extends \PHPUnit_Framework_TestCase
 
         $list = $this->helper->__invoke($items);
 
-        $this->assertContains('<ul>' . Helper\HtmlList::EOL, $list);
-        $this->assertContains('</ul>' . Helper\HtmlList::EOL, $list);
-        $this->assertContains('one<ul>' . Helper\HtmlList::EOL.'<li>four', $list);
-        $this->assertContains('<li>six</li>' . Helper\HtmlList::EOL . '</ul>' .
-            Helper\HtmlList::EOL . '</li>' . Helper\HtmlList::EOL . '<li>two', $list);
+        $this->assertContains('<ul>' . PHP_EOL, $list);
+        $this->assertContains('</ul>' . PHP_EOL, $list);
+        $this->assertContains('one<ul>' . PHP_EOL.'<li>four', $list);
+        $this->assertContains('<li>six</li>' . PHP_EOL . '</ul>' .
+            PHP_EOL . '</li>' . PHP_EOL . '<li>two', $list);
     }
 
     /*
@@ -124,12 +124,12 @@ class HtmlListTest extends \PHPUnit_Framework_TestCase
 
         $list = $this->helper->__invoke($items);
 
-        $this->assertContains('<ul>' . Helper\HtmlList::EOL, $list);
-        $this->assertContains('</ul>' . Helper\HtmlList::EOL, $list);
-        $this->assertContains('one<ul>' . Helper\HtmlList::EOL . '<li>four', $list);
-        $this->assertContains('<li>four<ul>' . Helper\HtmlList::EOL . '<li>six', $list);
-        $this->assertContains('<li>five</li>' . Helper\HtmlList::EOL . '</ul>' .
-            Helper\HtmlList::EOL . '</li>' . Helper\HtmlList::EOL . '<li>two', $list);
+        $this->assertContains('<ul>' . PHP_EOL, $list);
+        $this->assertContains('</ul>' . PHP_EOL, $list);
+        $this->assertContains('one<ul>' . PHP_EOL . '<li>four', $list);
+        $this->assertContains('<li>four<ul>' . PHP_EOL . '<li>six', $list);
+        $this->assertContains('<li>five</li>' . PHP_EOL . '</ul>' .
+            PHP_EOL . '</li>' . PHP_EOL . '<li>two', $list);
     }
 
     public function testListWithValuesToEscapeForZF2283()

--- a/test/Helper/Navigation/LinksTest.php
+++ b/test/Helper/Navigation/LinksTest.php
@@ -637,7 +637,7 @@ class LinksTest extends AbstractTest
             $this->_helper->setRenderFlag($newFlag);
             $expectedOutput = '<link '
                               . 'rel="' . $type . '" '
-                              . 'href="http&#x3A;&#x2F;&#x2F;www.example.com&#x2F;">' . constant($this->_helperName.'::EOL')
+                              . 'href="http&#x3A;&#x2F;&#x2F;www.example.com&#x2F;">' . PHP_EOL
                             . '<link '
                               . 'rev="' . $type . '" '
                               . 'href="http&#x3A;&#x2F;&#x2F;www.example.com&#x2F;">';
@@ -664,7 +664,7 @@ class LinksTest extends AbstractTest
 
         // test data
         $expected = '<link rel="next" href="page2" title="Page&#x20;2">'
-                  . constant($this->_helperName.'::EOL')
+                  . PHP_EOL
                   . '<link rel="prev" href="page1" title="Page&#x20;1">';
         $actual = $this->_helper->render();
 
@@ -682,7 +682,7 @@ class LinksTest extends AbstractTest
 
         // build expected and actual result
         $expected = '  <link rel="next" href="page2" title="Page&#x20;2">'
-                  . constant($this->_helperName.'::EOL')
+                  . PHP_EOL
                   . '  <link rel="prev" href="page1" title="Page&#x20;1">';
         $actual = $this->_helper->render();
 


### PR DESCRIPTION
in favor of https://github.com/zendframework/zf2/pull/7417