### PR TITLE
Add missing zend-filter dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "php": ">=5.5",
         "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-loader": "~2.5",
-        "zendframework/zend-stdlib": "~2.5"
+        "zendframework/zend-stdlib": "~2.5",
+	"zendframework/zend-filter": "~2.5"
     },
     "require-dev": {
         "zendframework/zend-authentication": "~2.5",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         "zendframework/zend-eventmanager": "~2.5",
         "zendframework/zend-loader": "~2.5",
         "zendframework/zend-stdlib": "~2.5",
-	"zendframework/zend-filter": "~2.5"
+        "zendframework/zend-filter": "~2.5"
     },
     "require-dev": {
         "zendframework/zend-authentication": "~2.5",


### PR DESCRIPTION
While trying to use zend-view with zend-expressive I got an exception:

`Fatal error: Class 'Zend\Filter\FilterChain' not found in \proophessor-do\vendor\zendframework\zend-view\src\Renderer\PhpRenderer.php on line 419`

`Zend\Filter\FilterChain` is required by the `PhpRenderer` to work correctly so `zend-filter` should be required in composer.json.