### PR TITLE
No invokable configuration

### DIFF
--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -10,6 +10,7 @@
 namespace Zend\View\Helper\Navigation;
 
 use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\InvokableFactory;
 use Zend\View\HelperPluginManager;
 
 /**
@@ -27,17 +28,27 @@ class PluginManager extends HelperPluginManager
     protected $instanceOf = AbstractHelper::class;
 
     /**
-     * Default configuration.
+     * Default aliases
      *
-     * @var array
+     * @var string[]
      */
-    protected $config = [
-        'invokables' => [
-            'breadcrumbs' => Breadcrumbs::class,
-            'links'       => Links::class,
-            'menu'        => Menu::class,
-            'sitemap'     => Sitemap::class,
-        ],
+    protected $aliases = [
+        'breadcrumbs' => Breadcrumbs::class,
+        'links'       => Links::class,
+        'menu'        => Menu::class,
+        'sitemap'     => Sitemap::class,
+    ];
+
+    /**
+     * Default factories
+     *
+     * @var string[]
+     */
+    protected $factories = [
+        Breadcrumbs::class => InvokableFactory::class,
+        Links::class       => InvokableFactory::class,
+        Menu::class        => InvokableFactory::class,
+        Sitemap::class     => InvokableFactory::class,
     ];
 
     /**
@@ -46,15 +57,13 @@ class PluginManager extends HelperPluginManager
      */
     public function __construct(ContainerInterface $container, array $config = [])
     {
-        $this->config['initializers'] = [
-            function ($container, $instance) {
-                if (! $instance instanceof AbstractHelper) {
-                    continue;
-                }
+        $this->initializers[] = function ($container, $instance) {
+            if (! $instance instanceof AbstractHelper) {
+                continue;
+            }
 
-                $instance->setServiceLocator($container);
-            },
-        ];
+            $instance->setServiceLocator($container);
+        };
 
         parent::__construct($container, $config);
     }

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -12,7 +12,7 @@ namespace Zend\View;
 use Interop\Container\ContainerInterface;
 use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\ServiceManager\AbstractPluginManager;
-use Zend\Stdlib\ArrayUtils;
+use Zend\ServiceManager\Factory\InvokableFactory;
 
 /**
  * Plugin manager implementation for view helpers
@@ -25,115 +25,159 @@ class HelperPluginManager extends AbstractPluginManager
 {
     protected $instanceOf = Helper\HelperInterface::class;
 
-    protected $config = [
-        'aliases' => [
-            'basePath'            => 'basepath',
-            'BasePath'            => 'basepath',
-            'Cycle'               => 'cycle',
-            'declareVars'         => 'declarevars',
-            'DeclareVars'         => 'declarevars',
-            'Doctype'             => 'doctype',
-            'flashMessenger'      => 'flashmessenger',
-            'FlashMessenger'      => 'flashmessenger',
-            'escapeHtml'          => 'escapehtml',
-            'EscapeHtml'          => 'escapehtml',
-            'escapeHtmlAttr'      => 'escapehtmlattr',
-            'EscapeHtmlAttr'      => 'escapehtmlattr',
-            'escapeJs'            => 'escapejs',
-            'EscapeJs'            => 'escapejs',
-            'escapeCss'           => 'escapecss',
-            'EscapeCss'           => 'escapecss',
-            'escapeUrl'           => 'escapeurl',
-            'EscapeUrl'           => 'escapeurl',
-            'Gravatar'            => 'gravatar',
-            'htmlTag'             => 'htmltag',
-            'HtmlTag'             => 'htmltag',
-            'headLink'            => 'headlink',
-            'HeadLink'            => 'headlink',
-            'headMeta'            => 'headmeta',
-            'HeadMeta'            => 'headmeta',
-            'headScript'          => 'headscript',
-            'HeadScript'          => 'headscript',
-            'headStyle'           => 'headstyle',
-            'HeadStyle'           => 'headstyle',
-            'headTitle'           => 'headtitle',
-            'HeadTitle'           => 'headtitle',
-            'htmlFlash'           => 'htmlflash',
-            'HtmlFlash'           => 'htmlflash',
-            'htmlList'            => 'htmllist',
-            'HtmlList'            => 'htmllist',
-            'htmlObject'          => 'htmlobject',
-            'HtmlObject'          => 'htmlobject',
-            'htmlPage'            => 'htmlpage',
-            'HtmlPage'            => 'htmlpage',
-            'htmlQuicktime'       => 'htmlquicktime',
-            'HtmlQuicktime'       => 'htmlquicktime',
-            'Identity'            => 'identity',
-            'inlineScript'        => 'inlinescript',
-            'InlineScript'        => 'inlinescript',
-            'Json'                => 'json',
-            'Layout'              => 'layout',
-            'paginationControl'   => 'paginationcontrol',
-            'PaginationControl'   => 'paginationcontrol',
-            'Partial'             => 'partial',
-            'partialLoop'         => 'partialloop',
-            'PartialLoop'         => 'partialloop',
-            'Placeholder'         => 'placeholder',
-            'renderChildModel'    => 'renderchildmodel',
-            'RenderChildModel'    => 'renderchildmodel',
-            'render_child_model'  => 'renderchildmodel',
-            'renderToPlaceholder' => 'rendertoplaceholder',
-            'RenderToPlaceholder' => 'rendertoplaceholder',
-            'serverUrl'           => 'serverurl',
-            'ServerUrl'           => 'serverurl',
-            'Url'                 => 'url',
-            'viewModel'           => 'viewmodel',
-            'ViewModel'           => 'viewmodel',
-            'view_model'          => 'viewmodel',
-        ],
-        'factories' => [
-            'flashmessenger' => Helper\Service\FlashMessengerFactory::class,
-            'identity'       => Helper\Service\IdentityFactory::class,
-        ],
-        'invokables' => [
-            // basepath, doctype, and url are set up as factories in the ViewHelperManagerFactory.
-            // basepath and url are not very useful without their factories, however the doctype
-            // helper works fine as an invokable. The factory for doctype simply checks for the
-            // config value from the merged config.
-            'basepath'            => Helper\BasePath::class,
-            'cycle'               => Helper\Cycle::class,
-            'declarevars'         => Helper\DeclareVars::class,
-            'doctype'             => Helper\Doctype::class, // overridden by a factory in ViewHelperManagerFactory
-            'escapehtml'          => Helper\EscapeHtml::class,
-            'escapehtmlattr'      => Helper\EscapeHtmlAttr::class,
-            'escapejs'            => Helper\EscapeJs::class,
-            'escapecss'           => Helper\EscapeCss::class,
-            'escapeurl'           => Helper\EscapeUrl::class,
-            'gravatar'            => Helper\Gravatar::class,
-            'htmltag'             => Helper\HtmlTag::class,
-            'headlink'            => Helper\HeadLink::class,
-            'headmeta'            => Helper\HeadMeta::class,
-            'headscript'          => Helper\HeadScript::class,
-            'headstyle'           => Helper\HeadStyle::class,
-            'headtitle'           => Helper\HeadTitle::class,
-            'htmlflash'           => Helper\HtmlFlash::class,
-            'htmllist'            => Helper\HtmlList::class,
-            'htmlobject'          => Helper\HtmlObject::class,
-            'htmlpage'            => Helper\HtmlPage::class,
-            'htmlquicktime'       => Helper\HtmlQuicktime::class,
-            'inlinescript'        => Helper\InlineScript::class,
-            'json'                => Helper\Json::class,
-            'layout'              => Helper\Layout::class,
-            'paginationcontrol'   => Helper\PaginationControl::class,
-            'partialloop'         => Helper\PartialLoop::class,
-            'partial'             => Helper\Partial::class,
-            'placeholder'         => Helper\Placeholder::class,
-            'renderchildmodel'    => Helper\RenderChildModel::class,
-            'rendertoplaceholder' => Helper\RenderToPlaceholder::class,
-            'serverurl'           => Helper\ServerUrl::class,
-            'url'                 => Helper\Url::class,
-            'viewmodel'           => Helper\ViewModel::class,
-        ],
+    /**
+     * Default helper aliases
+     *
+     * Most of these are present for legacy purposes, as v2 of the service
+     * manager normalized names when fetching services.
+     *
+     * @var string[]
+     */
+    protected $aliases = [
+        'basePath'            => 'basepath',
+        'BasePath'            => 'basepath',
+        'basepath'            => Helper\BasePath::class,
+        'Cycle'               => 'cycle',
+        'cycle'               => Helper\Cycle::class,
+        'declareVars'         => 'declarevars',
+        'DeclareVars'         => 'declarevars',
+        'declarevars'         => Helper\DeclareVars::class,
+        'Doctype'             => 'doctype',
+        'doctype'             => Helper\Doctype::class, // overridden by a factory in ViewHelperManagerFactory
+        'escapeCss'           => 'escapecss',
+        'EscapeCss'           => 'escapecss',
+        'escapecss'           => Helper\EscapeCss::class,
+        'escapeHtmlAttr'      => 'escapehtmlattr',
+        'EscapeHtmlAttr'      => 'escapehtmlattr',
+        'escapehtmlattr'      => Helper\EscapeHtmlAttr::class,
+        'escapeHtml'          => 'escapehtml',
+        'EscapeHtml'          => 'escapehtml',
+        'escapehtml'          => Helper\EscapeHtml::class,
+        'escapeJs'            => 'escapejs',
+        'EscapeJs'            => 'escapejs',
+        'escapejs'            => Helper\EscapeJs::class,
+        'escapeUrl'           => 'escapeurl',
+        'EscapeUrl'           => 'escapeurl',
+        'escapeurl'           => Helper\EscapeUrl::class,
+        'flashMessenger'      => 'flashmessenger',
+        'FlashMessenger'      => 'flashmessenger',
+        'Gravatar'            => 'gravatar',
+        'gravatar'            => Helper\Gravatar::class,
+        'headLink'            => 'headlink',
+        'HeadLink'            => 'headlink',
+        'headlink'            => Helper\HeadLink::class,
+        'headMeta'            => 'headmeta',
+        'HeadMeta'            => 'headmeta',
+        'headmeta'            => Helper\HeadMeta::class,
+        'headScript'          => 'headscript',
+        'HeadScript'          => 'headscript',
+        'headscript'          => Helper\HeadScript::class,
+        'headStyle'           => 'headstyle',
+        'HeadStyle'           => 'headstyle',
+        'headstyle'           => Helper\HeadStyle::class,
+        'headTitle'           => 'headtitle',
+        'HeadTitle'           => 'headtitle',
+        'headtitle'           => Helper\HeadTitle::class,
+        'htmlflash'           => Helper\HtmlFlash::class,
+        'htmlFlash'           => 'htmlflash',
+        'HtmlFlash'           => 'htmlflash',
+        'htmllist'            => Helper\HtmlList::class,
+        'htmlList'            => 'htmllist',
+        'HtmlList'            => 'htmllist',
+        'htmlobject'          => Helper\HtmlObject::class,
+        'htmlObject'          => 'htmlobject',
+        'HtmlObject'          => 'htmlobject',
+        'htmlpage'            => Helper\HtmlPage::class,
+        'htmlPage'            => 'htmlpage',
+        'HtmlPage'            => 'htmlpage',
+        'htmlquicktime'       => Helper\HtmlQuicktime::class,
+        'htmlQuicktime'       => 'htmlquicktime',
+        'HtmlQuicktime'       => 'htmlquicktime',
+        'htmltag'             => Helper\HtmlTag::class,
+        'htmlTag'             => 'htmltag',
+        'HtmlTag'             => 'htmltag',
+        'Identity'            => 'identity',
+        'inlinescript'        => Helper\InlineScript::class,
+        'inlineScript'        => 'inlinescript',
+        'InlineScript'        => 'inlinescript',
+        'json'                => Helper\Json::class,
+        'Json'                => 'json',
+        'layout'              => Helper\Layout::class,
+        'Layout'              => 'layout',
+        'paginationcontrol'   => Helper\PaginationControl::class,
+        'paginationControl'   => 'paginationcontrol',
+        'PaginationControl'   => 'paginationcontrol',
+        'partial'             => Helper\Partial::class,
+        'partialloop'         => Helper\PartialLoop::class,
+        'partialLoop'         => 'partialloop',
+        'PartialLoop'         => 'partialloop',
+        'Partial'             => 'partial',
+        'placeholder'         => Helper\Placeholder::class,
+        'Placeholder'         => 'placeholder',
+        'renderchildmodel'    => Helper\RenderChildModel::class,
+        'render_child_model'  => 'renderchildmodel',
+        'renderChildModel'    => 'renderchildmodel',
+        'RenderChildModel'    => 'renderchildmodel',
+        'rendertoplaceholder' => Helper\RenderToPlaceholder::class,
+        'renderToPlaceholder' => 'rendertoplaceholder',
+        'RenderToPlaceholder' => 'rendertoplaceholder',
+        'serverurl'           => Helper\ServerUrl::class,
+        'serverUrl'           => 'serverurl',
+        'ServerUrl'           => 'serverurl',
+        'url'                 => Helper\Url::class,
+        'Url'                 => 'url',
+        'viewmodel'           => Helper\ViewModel::class,
+        'view_model'          => 'viewmodel',
+        'viewModel'           => 'viewmodel',
+        'ViewModel'           => 'viewmodel',
+    ];
+
+    /**
+     * Default factories
+     *
+     * basepath, doctype, and url are set up as factories in the ViewHelperManagerFactory.
+     * basepath and url are not very useful without their factories, however the doctype
+     * helper works fine as an invokable. The factory for doctype simply checks for the
+     * config value from the merged config.
+     *
+     * @var array
+     */
+    protected $factories = [
+        'flashmessenger'                  => Helper\Service\FlashMessengerFactory::class,
+        'identity'                        => Helper\Service\IdentityFactory::class,
+        Helper\BasePath::class            => InvokableFactory::class,
+        Helper\Cycle::class               => InvokableFactory::class,
+        Helper\DeclareVars::class         => InvokableFactory::class,
+        Helper\Doctype::class             => InvokableFactory::class, // overridden by a factory in ViewHelperManagerFactory
+        Helper\EscapeHtml::class          => InvokableFactory::class,
+        Helper\EscapeHtmlAttr::class      => InvokableFactory::class,
+        Helper\EscapeJs::class            => InvokableFactory::class,
+        Helper\EscapeCss::class           => InvokableFactory::class,
+        Helper\EscapeUrl::class           => InvokableFactory::class,
+        Helper\Gravatar::class            => InvokableFactory::class,
+        Helper\HtmlTag::class             => InvokableFactory::class,
+        Helper\HeadLink::class            => InvokableFactory::class,
+        Helper\HeadMeta::class            => InvokableFactory::class,
+        Helper\HeadScript::class          => InvokableFactory::class,
+        Helper\HeadStyle::class           => InvokableFactory::class,
+        Helper\HeadTitle::class           => InvokableFactory::class,
+        Helper\HtmlFlash::class           => InvokableFactory::class,
+        Helper\HtmlList::class            => InvokableFactory::class,
+        Helper\HtmlObject::class          => InvokableFactory::class,
+        Helper\HtmlPage::class            => InvokableFactory::class,
+        Helper\HtmlQuicktime::class       => InvokableFactory::class,
+        Helper\InlineScript::class        => InvokableFactory::class,
+        Helper\Json::class                => InvokableFactory::class,
+        Helper\Layout::class              => InvokableFactory::class,
+        Helper\PaginationControl::class   => InvokableFactory::class,
+        Helper\PartialLoop::class         => InvokableFactory::class,
+        Helper\Partial::class             => InvokableFactory::class,
+        Helper\Placeholder::class         => InvokableFactory::class,
+        Helper\RenderChildModel::class    => InvokableFactory::class,
+        Helper\RenderToPlaceholder::class => InvokableFactory::class,
+        Helper\ServerUrl::class           => InvokableFactory::class,
+        Helper\Url::class                 => InvokableFactory::class,
+        Helper\ViewModel::class           => InvokableFactory::class,
     ];
 
     /**
@@ -154,11 +198,9 @@ class HelperPluginManager extends AbstractPluginManager
      */
     public function __construct(ContainerInterface $container, array $config = [])
     {
-        $this->config['initializers'] = [
-            [$this, 'injectRenderer'],
-            [$this, 'injectTranslator'],
-        ];
-        $config = ArrayUtils::merge($this->config, $config);
+        $this->initializers[] = [$this, 'injectRenderer'];
+        $this->initializers[] = [$this, 'injectTranslator'];
+
         parent::__construct($container, $config);
     }
 

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -13,6 +13,8 @@ use Zend\I18n\Translator\Translator;
 use Zend\Mvc\I18n\Translator as MvcTranslator;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\HelperPluginManager;
+use Zend\View\Helper\HelperInterface;
+use Zend\View\Helper\Url;
 use Zend\View\Renderer\PhpRenderer;
 
 /**
@@ -116,5 +118,16 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
         $helpers = new HelperPluginManager($services);
         $helper  = $helpers->get('HeadTitle');
         $this->assertSame($translator, $helper->getTranslator());
+    }
+
+    public function testCanOverrideAFactoryViaConfigurationPassedToConstructor()
+    {
+        $helper  = $this->prophesize(HelperInterface::class)->reveal();
+        $helpers = new HelperPluginManager(new ServiceManager(), ['factories' => [
+            Url::class => function ($container, $name, array $options = null) use ($helper) {
+                return $helper;
+            },
+        ]]);
+        $this->assertSame($helper, $helpers->get('url'));
     }
 }


### PR DESCRIPTION
It's better to define the services properly up front, and not use the `invokables` configuration for the plugin manager. One issue that arises with the `invokables` configuration is that it can override existing factories and aliases, which may not be what is intended. Defining them explicitly ensures that incoming configuration at instantiation can properly override the default services.

This fixes issues observed in zend-mvc in the ViewHelperPluginManagerFactory, whereby the override factories for the `url`, `doctype`, and `basepath` view helpers were not overwriting the defaults.