### PR TITLE
Avoid needless Zend\Filter dependency

### DIFF
--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -515,7 +515,11 @@ class PhpRenderer implements Renderer, TreeRendererInterface
 
         $this->setVars(array_pop($this->__varsCache));
 
-        return $this->getFilterChain()->filter($this->__content); // filter output
+        if ($this->__filterChain instanceof FilterChain) {
+            return $this->__filterChain->filter($this->__content); // filter output
+        }
+
+        return $this->__content;
     }
 
     /**

--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -442,4 +442,14 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(2, $this->renderer->sharedinstance());
         $this->assertEquals(3, $this->renderer->sharedinstance());
     }
+
+    public function testDoesNotCallFilterChainIfNoFilterChainWasSet()
+    {
+        $this->renderer->resolver()->addPath(__DIR__ . '/_templates');
+
+        $result = $this->renderer->render('empty.phtml');
+
+        $this->assertContains('Empty view', $result);
+        $this->assertAttributeEmpty('__filterChain', $this->renderer);
+    }
 }


### PR DESCRIPTION
As far I know the filter chain of `PhpRenderer` is not used by `Zend\Mvc` default rendering strategy (@weierophinney can you confirm?) and it seems like most users of `PhpRenderer` does not use the filter chain feature at all.

So I added this check to avoid `Zend\Filter` dependency when the filter chain is not explicity defined by `setFilterChain()` nor lazy initialized by `getFilterChain()`.

Maybe that fixes https://github.com/zendframework/zend-view/issues/3, https://github.com/zendframework/zend-view/pull/12 and https://github.com/zendframework/zend-view/pull/24.