### PR TITLE
Ensure HelperPluginManager constructor is forwards compatible

### DIFF
--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -235,15 +235,16 @@ class HelperPluginManager extends AbstractPluginManager
      * Adds initializers to inject the attached renderer and translator, if
      * any, to the currently requested helper.
      *
-     * @param ContainerInterface $container
-     * @param array $config
+     * @param null|ConfigInterface|ContainerInterface $configOrContainerInstance
+     * @param array $v3config If $configOrContainerInstance is a container, this
+     *     value will be passed to the parent constructor.
      */
-    public function __construct(ContainerInterface $container, array $config = [])
+    public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
         $this->initializers[] = [$this, 'injectRenderer'];
         $this->initializers[] = [$this, 'injectTranslator'];
 
-        parent::__construct($container, $config);
+        parent::__construct($configOrContainerInstance, $v3config);
     }
 
     /**

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -30,6 +30,32 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->helpers = new HelperPluginManager(new ServiceManager());
     }
 
+    /**
+     * @group 43
+     */
+    public function testConstructorArgumentsAreOptionalUnderV2()
+    {
+        if (method_exists($this->helpers, 'configure')) {
+            $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
+        }
+
+        $helpers = new HelperPluginManager();
+        $this->assertInstanceOf(HelperPluginManager::class, $helpers);
+    }
+
+    /**
+     * @group 43
+     */
+    public function testConstructorAllowsConfigInstanceAsFirstArgumentUnderV2()
+    {
+        if (method_exists($this->helpers, 'configure')) {
+            $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
+        }
+
+        $helpers = new HelperPluginManager(new Config([]));
+        $this->assertInstanceOf(HelperPluginManager::class, $helpers);
+    }
+
     public function testViewIsNullByDefault()
     {
         $this->assertNull($this->helpers->getRenderer());


### PR DESCRIPTION
Added tests to ensure the plugin manager can be instantiated with either no arguments, or a `Zend\ServiceManager\Config` argument, when under zend-servicemanager v2, and updated the code to comply with the signature of `AbstractPluginManager::__construct()`.

Fixes #43.