### PR TITLE
Ensure Navigation helper PluginManager is BC

### DIFF
--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -49,6 +49,13 @@ class PluginManager extends HelperPluginManager
         Links::class       => InvokableFactory::class,
         Menu::class        => InvokableFactory::class,
         Sitemap::class     => InvokableFactory::class,
+
+        // v2 canonical FQCNs
+
+        'zendviewhelpernavigationbreadcrumbs' => InvokableFactory::class,
+        'zendviewhelpernavigationlinks'       => InvokableFactory::class,
+        'zendviewhelpernavigationmenu'        => InvokableFactory::class,
+        'zendviewhelpernavigationsitemap'     => InvokableFactory::class,
     ];
 
     /**

--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -52,19 +52,20 @@ class PluginManager extends HelperPluginManager
     ];
 
     /**
-     * @param ContainerInterface $container
-     * @param array $config
+     * @param null|ConfigInterface|ContainerInterface $configOrContainerInstance
+     * @param array $v3config If $configOrContainerInstance is a container, this
+     *     value will be passed to the parent constructor.
      */
-    public function __construct(ContainerInterface $container, array $config = [])
+    public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
         $this->initializers[] = function ($container, $instance) {
             if (! $instance instanceof AbstractHelper) {
-                continue;
+                return;
             }
 
             $instance->setServiceLocator($container);
         };
 
-        parent::__construct($container, $config);
+        parent::__construct($configOrContainerInstance, $v3config);
     }
 }

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -273,16 +273,18 @@ class HelperPluginManager extends AbstractPluginManager
     /**
      * Inject a helper instance with the registered renderer
      *
-     * @param $first
-     * @param $second
+     * @param ContainerInterface|Helper\HelperInterface $first helper instance
+     *     under zend-servicemanager v2, ContainerInterface under v3.
+     * @param ContainerInterface|Helper\HelperInterface $second
+     *     ContainerInterface under zend-servicemanager v3, helper instance
+     *     under v2. Ignored regardless.
      */
     public function injectRenderer($first, $second)
     {
-        if ($first instanceof ContainerInterface) {
-            $helper = $second;
-        } else {
-            $helper = $first;
-        }
+        $helper = ($first instanceof ContainerInterface)
+            ? $second
+            : $first;
+
         $renderer = $this->getRenderer();
         if (null === $renderer) {
             return;
@@ -293,19 +295,32 @@ class HelperPluginManager extends AbstractPluginManager
     /**
      * Inject a helper instance with the registered translator
      *
-     * @param $first
-     * @param $second
+     * @param ContainerInterface|Helper\HelperInterface $first helper instance
+     *     under zend-servicemanager v2, ContainerInterface under v3.
+     * @param ContainerInterface|Helper\HelperInterface $second
+     *     ContainerInterface under zend-servicemanager v3, helper instance
+     *     under v2. Ignored regardless.
      */
     public function injectTranslator($first, $second)
     {
         if ($first instanceof ContainerInterface) {
+            // v3 usage
             $container = $first;
             $helper = $second;
         } else {
+            // v2 usage; grab the parent container
             $container = $second->getServiceLocator();
             $helper = $first;
         }
+
         if (! $helper instanceof TranslatorAwareInterface) {
+            return;
+        }
+
+        if (! $container) {
+            // Under zend-navigation v2.5, the navigation PluginManager is
+            // always lazy-loaded, which means it never has a parent
+            // container.
             return;
         }
 

--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View;
+
+use Zend\ServiceManager\Config;
+use Zend\ServiceManager\ServiceManager;
+use Zend\View\Helper\Navigation\PluginManager;
+
+/**
+ * @group      Zend_View
+ */
+class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->helpers = new PluginManager(new ServiceManager());
+    }
+
+    /**
+     * @group 43
+     */
+    public function testConstructorArgumentsAreOptionalUnderV2()
+    {
+        if (method_exists($this->helpers, 'configure')) {
+            $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
+        }
+
+        $helpers = new PluginManager();
+        $this->assertInstanceOf(PluginManager::class, $helpers);
+    }
+
+    /**
+     * @group 43
+     */
+    public function testConstructorAllowsConfigInstanceAsFirstArgumentUnderV2()
+    {
+        if (method_exists($this->helpers, 'configure')) {
+            $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
+        }
+
+        $helpers = new PluginManager(new Config([]));
+        $this->assertInstanceOf(PluginManager::class, $helpers);
+    }
+}

--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -7,10 +7,13 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-namespace ZendTest\View;
+namespace ZendTest\View\Helper\Navigation;
 
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+use Zend\View\Exception\InvalidHelperException;
+use Zend\View\Helper\Navigation\AbstractHelper;
 use Zend\View\Helper\Navigation\PluginManager;
 
 /**
@@ -18,9 +21,21 @@ use Zend\View\Helper\Navigation\PluginManager;
  */
 class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
 {
-    public function setUp()
+    use CommonPluginManagerTrait;
+
+    protected function getPluginManager()
     {
-        $this->helpers = new PluginManager(new ServiceManager());
+        return new PluginManager(new ServiceManager());
+    }
+
+    protected function getV2InvalidPluginException()
+    {
+        return InvalidHelperException::class;
+    }
+
+    protected function getInstanceOf()
+    {
+        return AbstractHelper::class;
     }
 
     /**
@@ -28,7 +43,8 @@ class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorArgumentsAreOptionalUnderV2()
     {
-        if (method_exists($this->helpers, 'configure')) {
+        $helpers = $this->getPluginManager();
+        if (method_exists($helpers, 'configure')) {
             $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
         }
 
@@ -41,7 +57,8 @@ class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorAllowsConfigInstanceAsFirstArgumentUnderV2()
     {
-        if (method_exists($this->helpers, 'configure')) {
+        $helpers = $this->getPluginManager();
+        if (method_exists($helpers, 'configure')) {
             $this->markTestSkipped('zend-servicemanager v3 plugin managers require a container argument');
         }
 

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -20,7 +20,7 @@ use Zend\View\HelperPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 
-class PluginManagerCompatibilityTest extends TestCase
+class HelperPluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -181,6 +181,12 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
      */
     public function testInjectTranslatorWillReturnEarlyIfThePluginManagerDoesNotHaveAParentContainer()
     {
+        if (method_exists($this->helpers, 'configure')) {
+            $this->markTestSkipped(
+                'Skip test when testing against zend-servicemanager v3, as that implementation '
+                . 'guarantees a parent container in plugin managers'
+            );
+        }
         $helpers = new HelperPluginManager();
         $helper = new HeadTitle();
         $this->assertNull($helpers->injectTranslator($helper, $helpers));

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -16,6 +16,7 @@ use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\ServiceManager;
 use Zend\View\Exception\InvalidHelperException;
 use Zend\View\HelperPluginManager;
+use Zend\View\Helper\HeadTitle;
 use Zend\View\Helper\HelperInterface;
 use Zend\View\Helper\Url;
 use Zend\View\Renderer\PhpRenderer;
@@ -173,6 +174,17 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
         $helpers = new HelperPluginManager($services);
         $helper  = $helpers->get('HeadTitle');
         $this->assertSame($translator, $helper->getTranslator());
+    }
+
+    /**
+     * @group 47
+     */
+    public function testInjectTranslatorWillReturnEarlyIfThePluginManagerDoesNotHaveAParentContainer()
+    {
+        $helpers = new HelperPluginManager();
+        $helper = new HeadTitle();
+        $this->assertNull($helpers->injectTranslator($helper, $helpers));
+        $this->assertNull($helper->getTranslator());
     }
 
     public function testCanOverrideAFactoryViaConfigurationPassedToConstructor()


### PR DESCRIPTION
Adds tests similar to those for the `HelperPluginManager` to ensure that the first argument to the `Navigation\PluginManager` is optional and/or accepts a `Zend\ServiceManager\Config` instance, and updates the constructor to work with both v2 and v3.

Fixes zendframework/zend-navigation#19 and zenframework/zend-view#45