### PR TITLE
Ensure navigation helpers are injected with application service container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
   - if [[ $ZEND_EVENTMANAGER_VERSION == '' ]]; then composer require --no-update "zendframework/zend-eventmanager:^3.0" ; fi
   - if [[ $ZEND_SERVICEMANAGER_VERSION != '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:$ZEND_SERVICEMANAGER_VERSION" ; fi
   - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer require --dev --no-update "zendframework/zend-servicemanager:^3.0.3" ; fi
-  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-mvc zendframework/zend-session ; fi
+  - if [[ $ZEND_SERVICEMANAGER_VERSION == '' ]]; then composer remove --dev --no-update zendframework/zend-modulemanager zendframework/zend-mvc zendframework/zend-session ; fi
 
 install:
   - travis_retry composer install --no-interaction --ignore-platform-reqs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file, in reverse chronological order by release.
 
-## 2.6.3 - TBD
+## 2.6.3 - 2016-02-19
 
 ### Added
 
@@ -18,7 +18,11 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#50](https://github.com/zendframework/zend-view/pull/50) fixes
+  the initializer defined and registered in
+  `Navigation\PluginManager::__construct()` to ensure it properly pulls and
+  injects the application container into navigation helpers, under both
+  zend-servicemanager v2 and v3.
 
 ## 2.6.2 - 2016-02-18
 

--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "zendframework/zend-i18n": "^2.6",
         "zendframework/zend-json": "^2.6.1",
         "zendframework/zend-log": "^2.7",
+        "zendframework/zend-modulemanager": "^2.5",
         "zendframework/zend-mvc": "^2.6.1",
         "zendframework/zend-navigation": "^2.5",
         "zendframework/zend-paginator": "^2.5",

--- a/src/Helper/Navigation.php
+++ b/src/Helper/Navigation.php
@@ -322,7 +322,7 @@ class Navigation extends AbstractNavigationHelper
     public function getPluginManager()
     {
         if (null === $this->plugins) {
-            $this->setPluginManager(new Navigation\PluginManager());
+            $this->setPluginManager(new Navigation\PluginManager($this->getServiceLocator()));
         }
 
         return $this->plugins;

--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -11,6 +11,7 @@ namespace Zend\View\Helper\Navigation;
 
 use Interop\Container\ContainerInterface;
 use RecursiveIteratorIterator;
+use ReflectionProperty;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\EventManagerInterface;
@@ -19,6 +20,7 @@ use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\Navigation;
 use Zend\Navigation\Page\AbstractPage;
 use Zend\Permissions\Acl;
+use Zend\ServiceManager\AbstractPluginManager;
 use Zend\View;
 use Zend\View\Exception;
 
@@ -753,6 +755,26 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
      */
     public function setServiceLocator(ContainerInterface $serviceLocator)
     {
+        // If we are provided a plugin manager, we should pull the parent
+        // context from it.
+        // @todo We should update tests and code to ensure that this situation
+        //       doesn't happen in the future.
+        if ($serviceLocator instanceof AbstractPluginManager
+            && ! method_exists($serviceLocator, 'configure')
+            && $serviceLocator->getServiceLocator()
+        ) {
+            $serviceLocator = $serviceLocator->getServiceLocator();
+        }
+
+        // v3 variant; likely won't be needed.
+        if ($serviceLocator instanceof AbstractPluginManager
+            && method_exists($serviceLocator, 'configure')
+        ) {
+            $r = new ReflectionProperty($serviceLocator, 'creationContext');
+            $r->setAccessible(true);
+            $serviceLocator = $r->getValue($serviceLocator);
+        }
+
         $this->serviceLocator = $serviceLocator;
         return $this;
     }

--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -65,9 +65,29 @@ class PluginManager extends HelperPluginManager
      */
     public function __construct($configOrContainerInstance = null, array $v3config = [])
     {
-        $this->initializers[] = function ($container, $instance) {
+        $this->initializers[] = function ($first, $second) {
+            // v2 vs v3 argument order
+            if ($first instanceof ContainerInterface) {
+                // v3
+                $container = $first;
+                $instance = $second;
+            } else {
+                // v2
+                $container = $second;
+                $instance = $first;
+            }
+
             if (! $instance instanceof AbstractHelper) {
                 return;
+            }
+
+            // This initializer was written with v2 functionality in mind; as such,
+            // we need to test and see if we're called in a v2 context, and, if so,
+            // set the service locator to the parent locator.
+            //
+            // Under v3, the parent locator is what is passed to the method already.
+            if (method_exists($container, 'getServiceLocator') && $container->getServiceLocator()) {
+                $container = $container->getServiceLocator();
             }
 
             $instance->setServiceLocator($container);

--- a/src/Helper/Navigation/PluginManager.php
+++ b/src/Helper/Navigation/PluginManager.php
@@ -86,7 +86,7 @@ class PluginManager extends HelperPluginManager
             // set the service locator to the parent locator.
             //
             // Under v3, the parent locator is what is passed to the method already.
-            if (method_exists($container, 'getServiceLocator') && $container->getServiceLocator()) {
+            if (! method_exists($container, 'configure') && $container->getServiceLocator()) {
                 $container = $container->getServiceLocator();
             }
 

--- a/test/Helper/Navigation/AbstractTest.php
+++ b/test/Helper/Navigation/AbstractTest.php
@@ -86,7 +86,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        if (! class_exists(PluginFlashMessenger::class)) {
+        if (! class_exists(ServiceManagerConfig::class)) {
             $this->markTestSkipped(
                 'Skipping zend-mvc-related tests until that component is updated '
                 . 'to be forwards-compatible with zend-eventmanager, zend-stdlib, '
@@ -139,7 +139,10 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
             ],
         ];
 
-        $sm = $this->serviceManager = new ServiceManager(new ServiceManagerConfig);
+        $sm = $this->serviceManager = new ServiceManager();
+        $sm->setAllowOverride(true);
+
+        (new ServiceManagerConfig())->configureServiceManager($sm);
         $sm->setService('ApplicationConfig', $smConfig);
         $sm->get('ModuleManager')->loadModules();
         $sm->get('Application')->bootstrap();
@@ -147,6 +150,8 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 
         $sm->setService('nav1', $this->_nav1);
         $sm->setService('nav2', $this->_nav2);
+
+        $sm->setAllowOverride(false);
 
         $app = $this->serviceManager->get('Application');
         $app->getMvcEvent()->setRouteMatch(new RouteMatch([

--- a/test/Helper/Navigation/AbstractTest.php
+++ b/test/Helper/Navigation/AbstractTest.php
@@ -126,7 +126,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
                 'extra_config'         => [
                     'service_manager' => [
                         'factories' => [
-                            'Config' => function () use ($config) {
+                            'config' => function () use ($config) {
                                 return [
                                     'navigation' => [
                                         'default' => $config->get('nav_test1'),

--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -67,13 +67,8 @@ class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(PluginManager::class, $helpers);
     }
 
-    public function testInjectsParentContainerIntoHelpersUnderV2()
+    public function testInjectsParentContainerIntoHelpers()
     {
-        $helpers = $this->getPluginManager();
-        if (method_exists($helpers, 'configure')) {
-            $this->markTestSkipped('This test is specific to v2 functionality');
-        }
-
         $config = new Config([
             'navigation' => [
                 'default' => [],

--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -14,6 +14,7 @@ use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
 use Zend\View\Exception\InvalidHelperException;
 use Zend\View\Helper\Navigation\AbstractHelper;
+use Zend\View\Helper\Navigation\Breadcrumbs;
 use Zend\View\Helper\Navigation\PluginManager;
 
 /**
@@ -64,5 +65,27 @@ class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
 
         $helpers = new PluginManager(new Config([]));
         $this->assertInstanceOf(PluginManager::class, $helpers);
+    }
+
+    public function testInjectsParentContainerIntoHelpersUnderV2()
+    {
+        $helpers = $this->getPluginManager();
+        if (method_exists($helpers, 'configure')) {
+            $this->markTestSkipped('This test is specific to v2 functionality');
+        }
+
+        $config = new Config([
+            'navigation' => [
+                'default' => [],
+            ],
+        ]);
+
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
+        $helpers = new PluginManager($services);
+
+        $helper = $helpers->get('breadcrumbs');
+        $this->assertInstanceOf(Breadcrumbs::class, $helper);
+        $this->assertSame($services, $helper->getServiceLocator());
     }
 }


### PR DESCRIPTION
With the update to 2.6.0, the navigation helpers no longer formally implement `ServiceLocatorAwareInterface`, though they continue to implement the methods. An initializer was added to the navigation-specific `PluginManager` to mimic the behavior, but was written incorrectly.

This patch:

- adds a test to demonstrate the behavior expected.
- updates the initializer to work correctly under both v2 and v3.

Fixes #49