### PR TITLE
Fix zendframework/zend-navigation#23

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Fixed
 
-- Nothing.
+- [#55](https://github.com/zendframework/zend-view/pull/55) fixes a circular
+  dependency issue in the navigation helpers with regards to event manager
+  resolution.
 
 ## 2.6.4 - 2016-03-02
 

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -375,6 +375,11 @@ class HelperPluginManager extends AbstractPluginManager
             return;
         }
 
+        if (! $container->has('EventManager')) {
+            // If the container doesn't have an EM service, do nothing.
+            return;
+        }
+
         $events = $helper->getEventManager();
         if (! $events || ! $events->getSharedManager() instanceof SharedEventManagerInterface) {
             $helper->setEventManager($container->get('EventManager'));

--- a/test/Helper/Navigation/AbstractHelperTest.php
+++ b/test/Helper/Navigation/AbstractHelperTest.php
@@ -76,4 +76,9 @@ class AbstractHelperTest extends AbstractTest
         $this->_helper->setRole($role);
         $this->assertEquals(true, $this->_helper->hasRole());
     }
+
+    public function testEventManagerIsNullByDefault()
+    {
+        $this->assertNull($this->_helper->getEventManager());
+    }
 }

--- a/test/Helper/Navigation/AbstractTest.php
+++ b/test/Helper/Navigation/AbstractTest.php
@@ -23,14 +23,9 @@ use ZendTest\View\Helper\TestAsset;
 
 /**
  * Base class for navigation view helper tests
- *
- * @group      Zend_View
- * @group      Zend_View_Helper
  */
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {
-    const REGISTRY_KEY = 'Zend_Navigation';
-
     /**
      * @var
      */


### PR DESCRIPTION
Running tests of zend-navigation against all v2 components (no v3 components) revealed a circular dependency condition in the navigation helpers related to `getEventManager()`.

In v2, `getEventManager()` has lazy-loaded an EM instance, and an initializer was checking the returned instance to see if its `SharedEventManager` instance was present and/or the same as the one in the container; if not, it was re-injecting the EM instance from the container.  Unfortunately, this fails now, as the call to `setEventManager()` now attaches the default listeners, and requires that a shared manager is present.

This patch changes the behavior to the following:

- `getEventManager()` now *never* lazy-loads an instance. This ensures that the initializer doesn't lead to lazy-population of the shared manager.
- `setEventManager()` was updated to check that we have a shared manager before attempting to call `setDefaultListeners()`.
- Internally, if an EM instance is needed, it now lazy-creates one, *with a shared manager*, and calls `setEventManager()` with the new EM instance.
- The EM initializer in the helper plugin manager was updated to first check that we have an `EventManager` instance before attempting to inject one.