### PR TITLE
Duck type TranslatorAwareInterface

### DIFF
--- a/src/Helper/FlashMessenger.php
+++ b/src/Helper/FlashMessenger.php
@@ -1,22 +1,23 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-view for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Zend\View\Helper;
 
 use Zend\Mvc\Controller\Plugin\FlashMessenger as PluginFlashMessenger;
-use Zend\I18n\View\Helper\AbstractTranslatorHelper;
 
 /**
  * Helper to proxy the plugin flash messenger
+ *
+ * Duck-types against Zend\I18n\Translator\TranslatorAwareInterface.
  */
-class FlashMessenger extends AbstractTranslatorHelper
+class FlashMessenger extends AbstractHelper
 {
+    use TranslatorAwareTrait;
+
     /**
      * Default attributes for the open format tag
      *
@@ -149,9 +150,9 @@ class FlashMessenger extends AbstractTranslatorHelper
         }
 
         // Flatten message array
-        $escapeHtml      = $this->getEscapeHtmlHelper();
-        $messagesToPrint = [];
-        $translator = $this->getTranslator();
+        $escapeHtml           = $this->getEscapeHtmlHelper();
+        $messagesToPrint      = [];
+        $translator           = $this->getTranslator();
         $translatorTextDomain = $this->getTranslatorTextDomain();
         array_walk_recursive(
             $messages,

--- a/src/Helper/HeadTitle.php
+++ b/src/Helper/HeadTitle.php
@@ -1,24 +1,23 @@
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
- * @link      http://github.com/zendframework/zf2 for the canonical source repository
- * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @link      http://github.com/zendframework/zend-view for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
 namespace Zend\View\Helper;
 
-use Zend\I18n\Translator\TranslatorInterface as Translator;
-use Zend\I18n\Translator\TranslatorAwareInterface;
 use Zend\View\Exception;
 
 /**
- * Helper for setting and retrieving title element for HTML head
+ * Helper for setting and retrieving title element for HTML head.
+ *
+ * Duck-types against Zend\I18n\Translator\TranslatorAwareInterface.
  */
-class HeadTitle extends Placeholder\Container\AbstractStandalone implements
-    TranslatorAwareInterface
+class HeadTitle extends Placeholder\Container\AbstractStandalone
 {
+    use TranslatorAwareTrait;
+
     /**
      * Registry key for placeholder
      *
@@ -32,27 +31,6 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
      * @var string
      */
     protected $defaultAttachOrder = null;
-
-    /**
-     * Translator (optional)
-     *
-     * @var Translator
-     */
-    protected $translator;
-
-    /**
-     * Translator text domain (optional)
-     *
-     * @var string
-     */
-    protected $translatorTextDomain = 'default';
-
-    /**
-     * Whether translator should be used
-     *
-     * @var bool
-     */
-    protected $translatorEnabled = true;
 
     /**
      * Retrieve placeholder for title element and optionally set state
@@ -109,14 +87,9 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
     {
         $items = [];
 
-        if (null !== ($translator = $this->getTranslator())) {
-            foreach ($this as $item) {
-                $items[] = $translator->translate($item, $this->getTranslatorTextDomain());
-            }
-        } else {
-            foreach ($this as $item) {
-                $items[] = $item;
-            }
+        $itemCallback = $this->getTitleItemCallback();
+        foreach ($this as $item) {
+            $items[] = $itemCallback($item);
         }
 
         $separator = $this->getSeparator();
@@ -172,92 +145,28 @@ class HeadTitle extends Placeholder\Container\AbstractStandalone implements
         return $this->defaultAttachOrder;
     }
 
-    // Translator methods - Good candidate to refactor as a trait with PHP 5.4
 
     /**
-     * Sets translator to use in helper
+     * Create and return a callback for normalizing title items.
      *
-     * @param  Translator $translator  [optional] translator.
-     *                                 Default is null, which sets no translator.
-     * @param  string     $textDomain  [optional] text domain
-     *                                 Default is null, which skips setTranslatorTextDomain
-     * @return HeadTitle
-     */
-    public function setTranslator(Translator $translator = null, $textDomain = null)
-    {
-        $this->translator = $translator;
-        if (null !== $textDomain) {
-            $this->setTranslatorTextDomain($textDomain);
-        }
-        return $this;
-    }
-
-    /**
-     * Returns translator used in helper
+     * If translation is not enabled, or no translator is present, returns a
+     * callable that simply returns the provided item; otherwise, returns a
+     * callable that returns a translation of the provided item.
      *
-     * @return Translator|null
+     * @return callable
      */
-    public function getTranslator()
+    private function getTitleItemCallback()
     {
-        if (! $this->isTranslatorEnabled()) {
-            return;
+        if (! $this->isTranslatorEnabled() || ! $this->hasTranslator()) {
+            return function ($item) {
+                return $item;
+            };
         }
 
-        return $this->translator;
-    }
-
-    /**
-     * Checks if the helper has a translator
-     *
-     * @return bool
-     */
-    public function hasTranslator()
-    {
-        return (bool) $this->getTranslator();
-    }
-
-    /**
-     * Sets whether translator is enabled and should be used
-     *
-     * @param  bool $enabled [optional] whether translator should be used.
-     *                       Default is true.
-     * @return HeadTitle
-     */
-    public function setTranslatorEnabled($enabled = true)
-    {
-        $this->translatorEnabled = (bool) $enabled;
-        return $this;
-    }
-
-    /**
-     * Returns whether translator is enabled and should be used
-     *
-     * @return bool
-     */
-    public function isTranslatorEnabled()
-    {
-        return $this->translatorEnabled;
-    }
-
-    /**
-     * Set translation text domain
-     *
-     * @param  string $textDomain
-     * @return HeadTitle
-     */
-    public function setTranslatorTextDomain($textDomain = 'default')
-    {
-        $this->translatorTextDomain = $textDomain;
-        return $this;
-    }
-
-    /**
-     * Return the translation text domain
-     *
-     * @return string
-     */
-    public function getTranslatorTextDomain()
-    {
-        return $this->translatorTextDomain;
+        $translator = $this->getTranslator();
+        $textDomain = $this->getTranslatorTextDomain();
+        return function ($item) use ($translator, $textDomain) {
+            return $translator->translate($item, $textDomain);
+        };
     }
 }

--- a/src/Helper/TranslatorAwareTrait.php
+++ b/src/Helper/TranslatorAwareTrait.php
@@ -1,0 +1,127 @@
+<?php
+/**
+ * @link      http://github.com/zendframework/zend-view for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Helper;
+
+use Zend\I18n\Translator\TranslatorInterface as Translator;
+
+/**
+ * Trait for implementing Zend\I18n\Translator\TranslatorAwareInterface.
+ *
+ * This can be used by helpers that need to implement the interface,
+ * whether via explicit implementation or duck typing.
+ */
+trait TranslatorAwareTrait
+{
+    /**
+     * Translator (optional)
+     *
+     * @var Translator
+     */
+    protected $translator;
+
+    /**
+     * Translator text domain (optional)
+     *
+     * @var string
+     */
+    protected $translatorTextDomain = 'default';
+
+    /**
+     * Whether translator should be used
+     *
+     * @var bool
+     */
+    protected $translatorEnabled = true;
+
+    /**
+     * Sets translator to use in helper
+     *
+     * @param  Translator $translator  [optional] translator.
+     *                                 Default is null, which sets no translator.
+     * @param  string     $textDomain  [optional] text domain
+     *                                 Default is null, which skips setTranslatorTextDomain
+     * @return HeadTitle
+     */
+    public function setTranslator(Translator $translator = null, $textDomain = null)
+    {
+        $this->translator = $translator;
+        if (null !== $textDomain) {
+            $this->setTranslatorTextDomain($textDomain);
+        }
+        return $this;
+    }
+
+    /**
+     * Returns translator used in helper
+     *
+     * @return Translator|null
+     */
+    public function getTranslator()
+    {
+        if (! $this->isTranslatorEnabled()) {
+            return;
+        }
+
+        return $this->translator;
+    }
+
+    /**
+     * Checks if the helper has a translator
+     *
+     * @return bool
+     */
+    public function hasTranslator()
+    {
+        return (bool) $this->getTranslator();
+    }
+
+    /**
+     * Sets whether translator is enabled and should be used
+     *
+     * @param  bool $enabled [optional] whether translator should be used.
+     *                       Default is true.
+     * @return HeadTitle
+     */
+    public function setTranslatorEnabled($enabled = true)
+    {
+        $this->translatorEnabled = (bool) $enabled;
+        return $this;
+    }
+
+    /**
+     * Returns whether translator is enabled and should be used
+     *
+     * @return bool
+     */
+    public function isTranslatorEnabled()
+    {
+        return $this->translatorEnabled;
+    }
+
+    /**
+     * Set translation text domain
+     *
+     * @param  string $textDomain
+     * @return HeadTitle
+     */
+    public function setTranslatorTextDomain($textDomain = 'default')
+    {
+        $this->translatorTextDomain = $textDomain;
+        return $this;
+    }
+
+    /**
+     * Return the translation text domain
+     *
+     * @return string
+     */
+    public function getTranslatorTextDomain()
+    {
+        return $this->translatorTextDomain;
+    }
+}

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -13,6 +13,7 @@ use Interop\Container\ContainerInterface;
 use Zend\EventManager\EventManagerAwareInterface;
 use Zend\EventManager\SharedEventManagerInterface;
 use Zend\I18n\Translator\TranslatorAwareInterface;
+use Zend\I18n\Translator\TranslatorInterface;
 use Zend\ServiceManager\AbstractPluginManager;
 use Zend\ServiceManager\Exception\InvalidServiceException;
 use Zend\ServiceManager\Factory\InvokableFactory;
@@ -316,7 +317,10 @@ class HelperPluginManager extends AbstractPluginManager
             $helper = $first;
         }
 
-        if (! $helper instanceof TranslatorAwareInterface) {
+        // Allow either direct implementation or duck-typing.
+        if (! $helper instanceof TranslatorAwareInterface
+            && ! method_exists($helper, 'setTranslator')
+        ) {
             return;
         }
 
@@ -332,8 +336,8 @@ class HelperPluginManager extends AbstractPluginManager
             return;
         }
 
-        if ($container->has('Zend\I18n\Translator\TranslatorInterface')) {
-            $helper->setTranslator($container->get('Zend\I18n\Translator\TranslatorInterface'));
+        if ($container->has(TranslatorInterface::class)) {
+            $helper->setTranslator($container->get(TranslatorInterface::class));
             return;
         }
 


### PR DESCRIPTION
Starting with zend-mvc 3, i18n features are considered opt-in and optional.  However, several official helpers in zend-view are translator-aware, and optionally expose translation features if a translator is composed.

This patch does the following:

- Introduces `TranslatorAwareTrait`, which encapsulates the logic for composing a translator and translation text domain. This logic was duplicated across multiple helpers already, and is simply extracted from it.
- Updates `FlashMessenger`, `HeadTitle`, and the navigation `AbstractHelper` to:
  - Remove the explicit implementation of `TranslatorAwareInterface`.
  - Use the new `TranslatorAwareTrait`, effectively duck typing `TranslatorAwareInterface`.
- Updates `HelperPluginManager` to inject a translator for helpers that either explicitly implement `TranslatorAwareInterface` or duck type it.

These changes fix issues when adapting the skeleton application to use the development branch of zend-mvc (future v3).