### PR TITLE
Allow usage of zend-router with Url helper

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,7 @@
         "zendframework/zend-navigation": "^2.5",
         "zendframework/zend-paginator": "^2.5",
         "zendframework/zend-permissions-acl": "^2.6",
+        "zendframework/zend-router": "^3.0.1",
         "zendframework/zend-serializer": "^2.6.1",
         "zendframework/zend-session": "^2.6.2",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "78643c6eff5703d3352a5e629428f53d",
-    "content-hash": "ba3f59cb1f8be8c9a2ce8c52a453c963",
+    "hash": "d634a6284e8740f145a4bc3105f2cc50",
+    "content-hash": "6dfe21b791ee28a1c61be0621461bd34",
     "packages": [
         {
             "name": "zendframework/zend-eventmanager",
@@ -2922,6 +2922,64 @@
                 "psr-7"
             ],
             "time": "2015-12-15 21:35:42"
+        },
+        {
+            "name": "zendframework/zend-router",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zendframework/zend-router.git",
+                "reference": "5a4666ced887d2a9e920e8aaa604b3cc39648b1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zendframework/zend-router/zipball/5a4666ced887d2a9e920e8aaa604b3cc39648b1a",
+                "reference": "5a4666ced887d2a9e920e8aaa604b3cc39648b1a",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.5 || ^7.0",
+                "zendframework/zend-http": "^2.5",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-stdlib": "^2.7.5 || ^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.5",
+                "sebastian/version": "^1.0.4",
+                "squizlabs/php_codesniffer": "^2.3",
+                "zendframework/zend-i18n": "^2.6"
+            },
+            "suggest": {
+                "zendframework/zend-i18n": "^2.6, if defining translatable HTTP path segments"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev",
+                    "dev-develop": "3.1-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Router",
+                    "config-provider": "Zend\\Router\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Zend\\Router\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "homepage": "https://github.com/zendframework/zend-router",
+            "keywords": [
+                "mvc",
+                "routing",
+                "zf2"
+            ],
+            "time": "2016-04-18 17:04:31"
         },
         {
             "name": "zendframework/zend-serializer",

--- a/src/Helper/Url.php
+++ b/src/Helper/Url.php
@@ -11,8 +11,10 @@ namespace Zend\View\Helper;
 
 use Traversable;
 use Zend\Mvc\ModuleRouteListener;
-use Zend\Mvc\Router\RouteMatch;
-use Zend\Mvc\Router\RouteStackInterface;
+use Zend\Mvc\Router\RouteMatch as LegacyRouteMatch;
+use Zend\Mvc\Router\RouteStackInterface as LegacyRouteStackInterface;
+use Zend\Router\RouteMatch;
+use Zend\Router\RouteStackInterface;
 use Zend\View\Exception;
 
 /**
@@ -21,32 +23,36 @@ use Zend\View\Exception;
 class Url extends AbstractHelper
 {
     /**
-     * RouteStackInterface instance.
+     * Router instance.
      *
-     * @var RouteStackInterface
+     * @var LegacyRouteStackInterface|RouteStackInterface
      */
     protected $router;
 
     /**
-     * RouteInterface match returned by the router.
+     * Route matches returned by the router.
      *
-     * @var RouteMatch.
+     * @var LegacyRouteMatch|RouteMatch.
      */
     protected $routeMatch;
 
     /**
      * Generates a url given the name of a route.
      *
-     * @see    Zend\Mvc\Router\RouteInterface::assemble()
-     * @param  string               $name               Name of the route
-     * @param  array                $params             Parameters for the link
-     * @param  array|Traversable    $options            Options for the route
-     * @param  bool                 $reuseMatchedParams Whether to reuse matched parameters
-     * @return string Url                         For the link href attribute
-     * @throws Exception\RuntimeException         If no RouteStackInterface was provided
-     * @throws Exception\RuntimeException         If no RouteMatch was provided
-     * @throws Exception\RuntimeException         If RouteMatch didn't contain a matched route name
-     * @throws Exception\InvalidArgumentException If the params object was not an array or \Traversable object
+     * @see Zend\Mvc\Router\RouteInterface::assemble()
+     * @see Zend\Router\RouteInterface::assemble()
+     * @param  string $name Name of the route
+     * @param  array $params Parameters for the link
+     * @param  array|Traversable $options Options for the route
+     * @param  bool $reuseMatchedParams Whether to reuse matched parameters
+     * @return string Url For the link href attribute
+     * @throws Exception\RuntimeException If no RouteStackInterface was
+     *     provided
+     * @throws Exception\RuntimeException If no RouteMatch was provided
+     * @throws Exception\RuntimeException If RouteMatch didn't contain a
+     *     matched route name
+     * @throws Exception\InvalidArgumentException If the params object was not
+     *     an array or Traversable object.
      */
     public function __invoke($name = null, $params = [], $options = [], $reuseMatchedParams = false)
     {
@@ -103,11 +109,24 @@ class Url extends AbstractHelper
     /**
      * Set the router to use for assembling.
      *
-     * @param RouteStackInterface $router
+     * @param LegacyRouteStackInterface|RouteStackInterface $router
      * @return Url
+     * @throws Exception\InvalidArgumentException for invalid router types.
      */
-    public function setRouter(RouteStackInterface $router)
+    public function setRouter($router)
     {
+        if (! $router instanceof RouteStackInterface
+            && ! $router instanceof LegacyRouteStackInterface
+        ) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a %s or %s instance; received %s',
+                __METHOD__,
+                RouteStackInterface::class,
+                LegacyRouteStackInterface::class,
+                (is_object($router) ? get_class($router) : gettype($router))
+            ));
+        }
+
         $this->router = $router;
         return $this;
     }
@@ -115,11 +134,23 @@ class Url extends AbstractHelper
     /**
      * Set route match returned by the router.
      *
-     * @param  RouteMatch $routeMatch
+     * @param  LegacyRouteMatch|RouteMatch $routeMatch
      * @return Url
      */
-    public function setRouteMatch(RouteMatch $routeMatch)
+    public function setRouteMatch($routeMatch)
     {
+        if (! $routeMatch instanceof RouteMatch
+            && ! $routeMatch instanceof LegacyRouteMatch
+        ) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s expects a %s or %s instance; received %s',
+                __METHOD__,
+                RouteMatch::class,
+                LegacyRouteMatch::class,
+                (is_object($routeMatch) ? get_class($routeMatch) : gettype($routeMatch))
+            ));
+        }
+
         $this->routeMatch = $routeMatch;
         return $this;
     }

--- a/test/Helper/UrlTest.php
+++ b/test/Helper/UrlTest.php
@@ -14,6 +14,8 @@ use Zend\Mvc\MvcEvent;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\Router\RouteMatch;
 use Zend\Mvc\Router\SimpleRouteStack as Router;
+use Zend\Router\RouteMatch as NextGenRouteMatch;
+use Zend\Router\SimpleRouteStack as NextGenRouter;
 
 /**
  * Zend\View\Helper\Url Test
@@ -200,5 +202,21 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
         $url = $helper->__invoke('default/wildcard', ['Twenty' => 'Cooler'], true);
         $this->assertEquals('/Rainbow/Dash=Twenty%Cooler', $url);
+    }
+
+    public function testAcceptsNextGenRouterToSetRouter()
+    {
+        $router = new NextGenRouter();
+        $url = new UrlHelper();
+        $url->setRouter($router);
+        $this->assertAttributeSame($router, 'router', $url);
+    }
+
+    public function testAcceptsNextGenRouteMatche()
+    {
+        $routeMatch = new NextGenRouteMatch([]);
+        $url = new UrlHelper();
+        $url->setRouteMatch($routeMatch);
+        $this->assertAttributeSame($routeMatch, 'routeMatch', $url);
     }
 }


### PR DESCRIPTION
This patch updates the `url()` helper to loosen up the typehints on `setRouter()` and `setRouteMatch()` such that they can accept the equivalents from the zend-router package.