### PR TITLE
Allow view helpers to be simple callables

### DIFF
--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -137,7 +137,7 @@ class HelperPluginManager extends AbstractPluginManager
         'ViewModel'           => Helper\ViewModel::class,
     ];
 
-    protected $instanceOf = Helper\HelperInterface::class;
+    protected $instanceOf = 'callable';
 
     /**
      * Default factories
@@ -289,6 +289,10 @@ class HelperPluginManager extends AbstractPluginManager
             ? $second
             : $first;
 
+        if (! $helper instanceof Helper\HelperInterface) {
+            return;
+        }
+
         $renderer = $this->getRenderer();
         if (null === $renderer) {
             return;
@@ -400,7 +404,17 @@ class HelperPluginManager extends AbstractPluginManager
      */
     public function validate($instance)
     {
-        if (!$instance instanceof $this->instanceOf) {
+        if ('callable' === $this->instanceOf) {
+            if (is_callable($instance)) {
+                return;
+            }
+
+            $instanceOf = Helper\HelperInterface::class;
+        } else {
+            $instanceOf = $this->instanceOf;
+        }
+
+        if (!$instance instanceof $instanceOf) {
             throw new InvalidServiceException(
                 sprintf(
                     '%s can only create instances of %s; %s is invalid',

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -11,14 +11,13 @@ namespace ZendTest\View;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
-use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Zend\Mvc\Controller\Plugin\FlashMessenger;
+use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
 use Zend\ServiceManager\Config;
-use Zend\View\Exception\InvalidHelperException;
-use Zend\View\Helper\HelperInterface;
-use Zend\View\HelperPluginManager;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
+use Zend\View\Exception\InvalidHelperException;
+use Zend\View\HelperPluginManager;
 
 class HelperPluginManagerCompatibilityTest extends TestCase
 {
@@ -58,7 +57,7 @@ class HelperPluginManagerCompatibilityTest extends TestCase
 
     protected function getInstanceOf()
     {
-        return HelperInterface::class;
+        return 'callable';
     }
 
     public function aliasProvider()

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -194,6 +194,23 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($helper, $helpers->get('url'));
     }
 
+    public function testCanUseCallableAsHelper()
+    {
+        $helper = function () {};
+        $helpers = new HelperPluginManager(new ServiceManager());
+        $config = new Config(
+            [
+                'factories' => [
+                    'foo' => function ($container) use ($helper) {
+                        return $helper;
+                    },
+                ]
+            ]
+        );
+        $config->configureServiceManager($helpers);
+        $this->assertSame($helper, $helpers->get('foo'));
+    }
+
     private function getServiceNotFoundException(HelperPluginManager $manager)
     {
         if (method_exists($manager, 'configure')) {


### PR DESCRIPTION
Currently, the user is forced to implement a `setView()` and `getView()` method in his view helpers, even though he's mostly likely not going to use them. This PR solves this by simply allowing any callable as a view helper. Extending classes can still specify a specific interface or class to check for, but the primary helper plugin manager now accepts any callable. This **should** be no BC break, but @weierophinney probably knows best.