### PR TITLE
Updated templatemap_generator to remove dep on zend-console

### DIFF
--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -6,21 +6,6 @@
  * @license   http://framework.zend.com/license/new-bsd New BSD License
  */
 
-// Setup/verify autoloading
-if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
-    // Local install
-    require __DIR__ . '/../vendor/autoload.php';
-} elseif (file_exists(getcwd() . '/vendor/autoload.php')) {
-    // Root project is current working directory
-    require getcwd() . '/vendor/autoload.php';
-} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
-    // Relative to composer install
-    require __DIR__ . '/../../../autoload.php';
-} else {
-    fwrite(STDERR, "Unable to setup autoloading; aborting\n");
-    exit(2);
-}
-
 $help = <<< EOH
 Generate template maps.
 

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -47,27 +47,27 @@ EOH;
 // Called without arguments
 if ($argc < 2) {
     fwrite(STDERR, 'No arguments provided.' . PHP_EOL . PHP_EOL);
-    fwrite(STDERR, $help);
+    fwrite(STDERR, $help . PHP_EOL);
     exit(2);
 }
 
 // Requested help
 if (in_array($argv[1], ['-h', '--help'], true)) {
-    echo $help, "\n";
+    echo $help, PHP_EOL;
     exit(0);
 }
 
 // Invalid path argument
 if (! is_dir($argv[1])) {
     fwrite(STDERR, 'templatepath argument is not a directory.' . PHP_EOL . PHP_EOL);
-    fwrite(STDERR, $help);
+    fwrite(STDERR, $help . PHP_EOL);
     exit(2);
 }
 
 // Not enough arguments
 if ($argc < 3) {
     fwrite(STDERR, 'No files specified.' . PHP_EOL . PHP_EOL);
-    fwrite(STDERR, $help);
+    fwrite(STDERR, $help . PHP_EOL);
     exit(2);
 }
 

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -30,6 +30,11 @@ to a file (which may have unexpected and/or intended results; you will
 need to edit the file after generation to ensure it contains valid
 PHP).
 
+We recommend you then include the generated file within your module
+configuration:
+
+  'template_map' => include __DIR__ . '/template_map.config.php',
+
 If only the templatepath argument is provided, the script will look for
 all .phtml files under that directory, creating a map for you.
 
@@ -45,11 +50,6 @@ For zsh, or bash where you have enabled globstar (`shopt  -s globstar` in
 either your bash profile or from within your terminal):
 
     ../view/**/*.phtml
-
-We recommend you then include the generated file within your module
-configuration:
-
-  'template_map' => include __DIR__ . '/template_map.config.php',
 
 Examples:
 

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -30,6 +30,17 @@ to a file (which may have unexpected and/or intended results; you will
 need to edit the file after generation to ensure it contains valid
 PHP).
 
+To provide a list of files, we recommend using one of the following.
+
+For any shell, you can pipe the results of `find`:
+
+    $(find ../view -name '*.phtml')
+
+For zsh, or bash where you have enabled globstar (`shopt  -s globstar` in
+either your bash profile or from within your terminal):
+
+    ../view/**/*.phtml
+
 We recommend you then include the generated file within your module
 configuration:
 
@@ -42,6 +53,11 @@ Examples:
   # .phtml files; overwrite any existing files:
   $ cd module/Application/config/
   $ ../../../vendor/bin/templatemap_generator.php ../view ../view/**/*.phtml > template_map.config.php
+
+  # OR using find:
+  $ ../../../vendor/bin/templatemap_generator.php \
+  > ../view \
+  > $(find ../view -name '*.phtml') > template_map.config.php
 EOH;
 
 // Called without arguments

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -1,30 +1,9 @@
 #!/usr/bin/env php
 <?php
 /**
- * Zend Framework (http://framework.zend.com/)
- *
  * @link      http://github.com/zendframework/zend-view for the canonical source repository
  * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   http://framework.zend.com/license/new-bsd New BSD License
- */
-
-use Zend\Console;
-
-/**
- * Generate template maps.
- *
- * Usage:
- * --help|-h                    Get usage message
- * --library|-l [ <string> ]    Library to parse; if none provided, assumes
- *                              current directory
- * --view|-v [ <string> ]       View path to parse; if none provided, assumes
- *                              view as template directory
- * --extensions|-e [ <string> ] List of accepted file extensions (regex alternation
- *                              without parenthesis); default: *
- * --output|-o [ <string> ]     Where to write map file; if not provided,
- *                              assumes "template_map.php" in library directory
- * --append|-a                  Append to map file if it exists
- * --overwrite|-w               Whether or not to overwrite existing map file
  */
 
 // Setup/verify autoloading
@@ -42,214 +21,91 @@ if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
     exit(2);
 }
 
-$libraryPath = getcwd();
-$viewPath    = getcwd() . '/view';
+$help = <<< EOH
+Generate template maps.
 
-$rules = [
-    'help|h'         => 'Get usage message',
-    'library|l-s'    => 'Library to parse; if none provided, assumes current directory',
-    'view|v-s'       => 'View path to parse; if none provided, assumes view as template directory',
-    'extensions|e-s' => 'List of accepted file extensions (regex alternation: *html, phtml|tpl); default: *',
-    'output|o-s'     => 'Where to write map file; if not provided, assumes "template_map.php" in library directory',
-    'append|a'       => 'Append to map file if it exists',
-    'overwrite|w'    => 'Whether or not to overwrite existing map file',
-];
+Usage:
 
-try {
-    $opts = new Console\Getopt($rules);
-    $opts->parse();
-} catch (Console\Exception\RuntimeException $e) {
-    echo $e->getUsageMessage();
+templatemap_generator.php [-h|--help] templatepath files...
+
+--help|-h                    Print this usage message.
+templatepath                 Path to templates relative to current working
+                             path; used to identify what to strip from
+                             template names.
+files...                     List of files to include in the template
+                             map, relative to the current working path.
+
+The script assumes that paths included in the template map are relative
+to the current working directory.
+
+The script will output a PHP script that will return the template map
+on successful completion. You may save this to a file using standard
+piping operators; use ">" to write to/ovewrite a file, ">>" to append
+to a file (which may have unexpected and/or intended results; you will
+need to edit the file after generation to ensure it contains valid
+PHP).
+
+We recommend you then include the generated file within your module
+configuration:
+
+  'template_map' => include __DIR__ . '/template_map.config.php',
+
+Examples:
+
+  # Create a template_map.config.php file in the Application module's
+  # config directory, relative to the view directory, and only containing
+  # .phtml files; overwrite any existing files:
+  $ cd module/Application/config/
+  $ ../../../vendor/bin/templatemap_generator.php ../view/**/*.phtml > template_map.config.php
+EOH;
+
+// Called without arguments
+if ($argc < 2) {
+    echo $help;
     exit(2);
 }
 
-if ($opts->getOption('h')) {
-    echo $opts->getUsageMessage();
+// Requested help
+if (in_array($argv[1], ['-h', '--help'], true)) {
+    echo $help, "\n";
     exit(0);
 }
 
-$fileExtensions = '*';
-if (isset($opts->e) && $opts->e != '*') {
-    if (!preg_match('/^(\*?[[:alnum:]]\*?+\|?)+$/', $opts->e)) {
-        echo 'Invalid extensions list specified. Expecting wildcard or alternation: *, *html, phtml|tpl' . PHP_EOL
-            . PHP_EOL;
-        echo $opts->getUsageMessage();
-        exit(2);
-    }
-    $fileExtensions = '(' . $opts->e . ')';
-}
-$fileExtensions = str_replace('*', '.*', $fileExtensions);
-
-$relativePathForMap = '';
-if (isset($opts->l)) {
-    if (!is_dir($opts->l)) {
-        echo 'Invalid library directory provided' . PHP_EOL
-            . PHP_EOL;
-        echo $opts->getUsageMessage();
-        exit(2);
-    }
-    $libraryPath = $opts->l;
-}
-$libraryPath = str_replace(DIRECTORY_SEPARATOR, '/', realpath($libraryPath));
-
-if (isset($opts->v)) {
-    if (!is_dir($opts->v)) {
-        echo 'Invalid view template directory provided' . PHP_EOL
-            . PHP_EOL;
-        echo $opts->getUsageMessage();
-        exit(2);
-    }
-    $viewPath = $opts->v;
-}
-
-if (!is_dir($viewPath)) {
-    printf('Invalid view path provided (%s)', $viewPath);
-    echo PHP_EOL . PHP_EOL;
-    echo $opts->getUsageMessage();
+// Not enough arguments
+if ($argc < 3) {
+    echo $help;
     exit(2);
 }
 
-$viewPath = str_replace(DIRECTORY_SEPARATOR, '/', realpath($viewPath));
+$basePath = $argv[1];
+$files    = array_slice($argv, 2);
+$map      = [];
+$realPath = realpath($basePath);
 
-$usingStdout = false;
-$appending   = $opts->getOption('a');
-$output      = $libraryPath . '/template_map.php';
-if (isset($opts->o)) {
-    $output = $opts->o;
-    if ('-' == $output) {
-        $output = STDOUT;
-        $usingStdout = true;
-    } elseif (is_dir($output)) {
-        echo 'Invalid output file provided' . PHP_EOL
-            . PHP_EOL;
-        echo $opts->getUsageMessage();
-        exit(2);
-    } elseif (!is_writeable(dirname($output))) {
-        echo "Cannot write to '$output'; aborting." . PHP_EOL
-            . PHP_EOL
-            . $opts->getUsageMessage();
-        exit(2);
-    } elseif (file_exists($output) && !$opts->getOption('w') && !$appending) {
-        echo "Template map file already exists at '$output'," . PHP_EOL
-            . "but 'overwrite' or 'appending' flag was not specified; aborting." . PHP_EOL
-            . PHP_EOL
-            . $opts->getUsageMessage();
-        exit(2);
-    } else {
-        // We need to add the $libraryPath into the relative path that is created in the template map file.
-        $mapPath = str_replace(DIRECTORY_SEPARATOR, '/', realpath(dirname($output)));
+$entries = array_map(function ($file) use ($basePath, $realPath) {
+    $file     = str_replace('\\', '/', $file);
 
-        // Simple case: $libraryPathCompare is in $mapPathCompare
-        if (strpos($libraryPath, $mapPath) === 0) {
-            $relativePathForMap = substr($libraryPath, strlen($mapPath) + 1) . '/';
-        } else {
-            $libraryPathParts  = explode('/', $libraryPath);
-            $mapPathParts = explode('/', $mapPath);
+    $template = (0 === strpos($file, $realPath))
+        ? substr($file, strlen($realPath))
+        : $file;
 
-            // Find the common part
-            $count = count($mapPathParts);
-            for ($i = 0; $i < $count; $i++) {
-                if (!isset($libraryPathParts[$i]) || $libraryPathParts[$i] != $mapPathParts[$i]) {
-                    // Common part end
-                    break;
-                }
-            }
+    $template = (0 === strpos($template, $basePath))
+        ? substr($template, strlen($basePath))
+        : $template;
 
-            // Add parent dirs for the subdirs of map
-            $relativePathForMap = str_repeat('../', $count - $i);
+    $template = preg_match('#(?P<template>.*?)\.[a-z0-9]+$#i', $template, $matches)
+        ? $matches['template']
+        : $template;
 
-            // Add library subdirs
-            $count = count($libraryPathParts);
-            for (; $i < $count; $i++) {
-                $relativePathForMap .= $libraryPathParts[$i] . '/';
-            }
-        }
-    }
-}
+    $template = str_replace('\\', '/', $template);
+    $template = preg_replace('#^\.*/#', '', $template);
+    $file     = sprintf('__DIR__ . \'%s\'', $file);
 
-if (!$usingStdout) {
-    if ($appending) {
-        echo "Appending to template file map '$output' for library in '$libraryPath'..." . PHP_EOL;
-    } else {
-        echo "Creating template file map for library in '$libraryPath'..." . PHP_EOL;
-    }
-}
+    return sprintf("    '%s' => %s,\n", $template, $file);
+}, $files);
 
-$dirOrIterator = new RecursiveDirectoryIterator($viewPath, RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
-$l = new RecursiveIteratorIterator($dirOrIterator);
+echo '<' . "?php\nreturn [\n"
+    . implode('', $entries)
+    . '];';
 
-// Iterate over each element in the path, and create a map of
-// template name => filename, where the filename is relative to the view path
-$map = new stdClass;
-foreach ($l as $file) {
-    /* @var $file SplFileInfo */
-    if (!$file->isFile() || !preg_match('/^' . $fileExtensions . '$/', $file->getExtension())) {
-        continue;
-    }
-    $filename  = str_replace($libraryPath . '/', '', str_replace(DIRECTORY_SEPARATOR, '/', $file->getPath()) . '/' . $file->getFilename());
-
-    // Add in relative path to library
-    $filename = $relativePathForMap . $filename;
-    $baseName = $file->getBasename('.' . pathinfo($file->getFilename(), PATHINFO_EXTENSION));
-    $mapName  = str_replace(str_replace(DIRECTORY_SEPARATOR, '/', realpath($viewPath)) . '/', '', str_replace(DIRECTORY_SEPARATOR, '/', $file->getPath()) . '/' . $baseName);
-    $map->{$mapName} = $filename;
-}
-
-// Create a file with the map.
-
-if ($appending && file_exists($output) && is_array(include $output)) {
-    // Append mode and the output file already exists: retrieve its
-    // content and merges with the new map
-    // Remove the last line as it is the end of the array, and we want to
-    // append our new templates
-    $content = file($output, FILE_IGNORE_NEW_LINES);
-    array_pop($content);
-    $content = implode(PHP_EOL, $content) . PHP_EOL;
-} else {
-    // Write mode or the file does not exists: create a new file
-    // Stupid syntax highlighters make separating < from PHP declaration necessary
-    $content = '<' . "?php" . PHP_EOL
-        . '// Generated by Zend\View\'s ./bin/templatemap_generator.php'  . PHP_EOL
-        . 'return array(' . PHP_EOL;
-}
-
-// Process the template map as a string before inserting it to the output file
-
-$mapExport = var_export((array) $map, true);
-
-// Prefix with __DIR__
-$mapExport = preg_replace("#(=> ')#", "=> __DIR__ . '/", $mapExport);
-
-// Fix \' strings from injected DIRECTORY_SEPARATOR usage in iterator_apply op
-$mapExport = str_replace("\\'", "'", $mapExport);
-
-// Remove unnecessary double-backslashes
-$mapExport = str_replace('\\\\', '\\', $mapExport);
-
-// Remove "array ("
-$mapExport = str_replace('array (', '', $mapExport);
-
-// Align "=>" operators to match coding standard
-preg_match_all('(\n\s+([^=]+)=>)', $mapExport, $matches, PREG_SET_ORDER);
-$maxWidth = 0;
-
-foreach ($matches as $match) {
-    $maxWidth = max($maxWidth, strlen($match[1]));
-}
-
-$mapExport = preg_replace_callback('(\n\s+([^=]+)=>)', function ($matches) use ($maxWidth) {
-    return PHP_EOL . '    ' . $matches[1] . str_repeat(' ', $maxWidth - strlen($matches[1])) . '=>';
-}, $mapExport);
-
-// Trim the content
-$mapExport = trim($mapExport, "\n");
-
-// Append the map to the file, close the array and write a new line
-$content .= $mapExport . ';' . PHP_EOL;
-
-// Write the contents to disk
-file_put_contents($output, $content);
-
-if (!$usingStdout) {
-    echo "Wrote templatemap file to '" . realpath($output) . "'" . PHP_EOL;
-}
+exit(0);

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -56,7 +56,7 @@ Examples:
   # config directory, relative to the view directory, and only containing
   # .phtml files; overwrite any existing files:
   $ cd module/Application/config/
-  $ ../../../vendor/bin/templatemap_generator.php ../view/**/*.phtml > template_map.config.php
+  $ ../../../vendor/bin/templatemap_generator.php ../view ../view/**/*.phtml > template_map.config.php
 EOH;
 
 // Called without arguments
@@ -97,7 +97,6 @@ $entries = array_map(function ($file) use ($basePath, $realPath) {
         ? $matches['template']
         : $template;
 
-    $template = str_replace('\\', '/', $template);
     $template = preg_replace('#^\.*/#', '', $template);
     $file     = sprintf('__DIR__ . \'%s\'', $file);
 

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -31,7 +31,7 @@ templatemap_generator.php [-h|--help] templatepath files...
 --help|-h                    Print this usage message.
 templatepath                 Path to templates relative to current working
                              path; used to identify what to strip from
-                             template names.
+                             template names. Must be a directory.
 files...                     List of files to include in the template
                              map, relative to the current working path.
 
@@ -61,6 +61,7 @@ EOH;
 
 // Called without arguments
 if ($argc < 2) {
+    fwrite(STDERR, 'No arguments provided.' . PHP_EOL . PHP_EOL);
     fwrite(STDERR, $help);
     exit(2);
 }
@@ -71,8 +72,16 @@ if (in_array($argv[1], ['-h', '--help'], true)) {
     exit(0);
 }
 
+// Invalid path argument
+if (! is_dir($argv[1])) {
+    fwrite(STDERR, 'templatepath argument is not a directory.' . PHP_EOL . PHP_EOL);
+    fwrite(STDERR, $help);
+    exit(2);
+}
+
 // Not enough arguments
 if ($argc < 3) {
+    fwrite(STDERR, 'No files specified.' . PHP_EOL . PHP_EOL);
     fwrite(STDERR, $help);
     exit(2);
 }

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -1,0 +1,255 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zend-view for the canonical source repository
+ * @copyright Copyright (c) 2005-2016 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+use Zend\Console;
+
+/**
+ * Generate template maps.
+ *
+ * Usage:
+ * --help|-h                    Get usage message
+ * --library|-l [ <string> ]    Library to parse; if none provided, assumes
+ *                              current directory
+ * --view|-v [ <string> ]       View path to parse; if none provided, assumes
+ *                              view as template directory
+ * --extensions|-e [ <string> ] List of accepted file extensions (regex alternation
+ *                              without parenthesis); default: *
+ * --output|-o [ <string> ]     Where to write map file; if not provided,
+ *                              assumes "template_map.php" in library directory
+ * --append|-a                  Append to map file if it exists
+ * --overwrite|-w               Whether or not to overwrite existing map file
+ */
+
+// Setup/verify autoloading
+if (file_exists(__DIR__ . '/../vendor/autoload.php')) {
+    // Local install
+    require __DIR__ . '/../vendor/autoload.php';
+} elseif (file_exists(getcwd() . '/vendor/autoload.php')) {
+    // Root project is current working directory
+    require getcwd() . '/vendor/autoload.php';
+} elseif (file_exists(__DIR__ . '/../../../autoload.php')) {
+    // Relative to composer install
+    require __DIR__ . '/../../../autoload.php';
+} else {
+    fwrite(STDERR, "Unable to setup autoloading; aborting\n");
+    exit(2);
+}
+
+$libraryPath = getcwd();
+$viewPath    = getcwd() . '/view';
+
+$rules = [
+    'help|h'         => 'Get usage message',
+    'library|l-s'    => 'Library to parse; if none provided, assumes current directory',
+    'view|v-s'       => 'View path to parse; if none provided, assumes view as template directory',
+    'extensions|e-s' => 'List of accepted file extensions (regex alternation: *html, phtml|tpl); default: *',
+    'output|o-s'     => 'Where to write map file; if not provided, assumes "template_map.php" in library directory',
+    'append|a'       => 'Append to map file if it exists',
+    'overwrite|w'    => 'Whether or not to overwrite existing map file',
+];
+
+try {
+    $opts = new Console\Getopt($rules);
+    $opts->parse();
+} catch (Console\Exception\RuntimeException $e) {
+    echo $e->getUsageMessage();
+    exit(2);
+}
+
+if ($opts->getOption('h')) {
+    echo $opts->getUsageMessage();
+    exit(0);
+}
+
+$fileExtensions = '*';
+if (isset($opts->e) && $opts->e != '*') {
+    if (!preg_match('/^(\*?[[:alnum:]]\*?+\|?)+$/', $opts->e)) {
+        echo 'Invalid extensions list specified. Expecting wildcard or alternation: *, *html, phtml|tpl' . PHP_EOL
+            . PHP_EOL;
+        echo $opts->getUsageMessage();
+        exit(2);
+    }
+    $fileExtensions = '(' . $opts->e . ')';
+}
+$fileExtensions = str_replace('*', '.*', $fileExtensions);
+
+$relativePathForMap = '';
+if (isset($opts->l)) {
+    if (!is_dir($opts->l)) {
+        echo 'Invalid library directory provided' . PHP_EOL
+            . PHP_EOL;
+        echo $opts->getUsageMessage();
+        exit(2);
+    }
+    $libraryPath = $opts->l;
+}
+$libraryPath = str_replace(DIRECTORY_SEPARATOR, '/', realpath($libraryPath));
+
+if (isset($opts->v)) {
+    if (!is_dir($opts->v)) {
+        echo 'Invalid view template directory provided' . PHP_EOL
+            . PHP_EOL;
+        echo $opts->getUsageMessage();
+        exit(2);
+    }
+    $viewPath = $opts->v;
+}
+
+if (!is_dir($viewPath)) {
+    printf('Invalid view path provided (%s)', $viewPath);
+    echo PHP_EOL . PHP_EOL;
+    echo $opts->getUsageMessage();
+    exit(2);
+}
+
+$viewPath = str_replace(DIRECTORY_SEPARATOR, '/', realpath($viewPath));
+
+$usingStdout = false;
+$appending   = $opts->getOption('a');
+$output      = $libraryPath . '/template_map.php';
+if (isset($opts->o)) {
+    $output = $opts->o;
+    if ('-' == $output) {
+        $output = STDOUT;
+        $usingStdout = true;
+    } elseif (is_dir($output)) {
+        echo 'Invalid output file provided' . PHP_EOL
+            . PHP_EOL;
+        echo $opts->getUsageMessage();
+        exit(2);
+    } elseif (!is_writeable(dirname($output))) {
+        echo "Cannot write to '$output'; aborting." . PHP_EOL
+            . PHP_EOL
+            . $opts->getUsageMessage();
+        exit(2);
+    } elseif (file_exists($output) && !$opts->getOption('w') && !$appending) {
+        echo "Template map file already exists at '$output'," . PHP_EOL
+            . "but 'overwrite' or 'appending' flag was not specified; aborting." . PHP_EOL
+            . PHP_EOL
+            . $opts->getUsageMessage();
+        exit(2);
+    } else {
+        // We need to add the $libraryPath into the relative path that is created in the template map file.
+        $mapPath = str_replace(DIRECTORY_SEPARATOR, '/', realpath(dirname($output)));
+
+        // Simple case: $libraryPathCompare is in $mapPathCompare
+        if (strpos($libraryPath, $mapPath) === 0) {
+            $relativePathForMap = substr($libraryPath, strlen($mapPath) + 1) . '/';
+        } else {
+            $libraryPathParts  = explode('/', $libraryPath);
+            $mapPathParts = explode('/', $mapPath);
+
+            // Find the common part
+            $count = count($mapPathParts);
+            for ($i = 0; $i < $count; $i++) {
+                if (!isset($libraryPathParts[$i]) || $libraryPathParts[$i] != $mapPathParts[$i]) {
+                    // Common part end
+                    break;
+                }
+            }
+
+            // Add parent dirs for the subdirs of map
+            $relativePathForMap = str_repeat('../', $count - $i);
+
+            // Add library subdirs
+            $count = count($libraryPathParts);
+            for (; $i < $count; $i++) {
+                $relativePathForMap .= $libraryPathParts[$i] . '/';
+            }
+        }
+    }
+}
+
+if (!$usingStdout) {
+    if ($appending) {
+        echo "Appending to template file map '$output' for library in '$libraryPath'..." . PHP_EOL;
+    } else {
+        echo "Creating template file map for library in '$libraryPath'..." . PHP_EOL;
+    }
+}
+
+$dirOrIterator = new RecursiveDirectoryIterator($viewPath, RecursiveDirectoryIterator::FOLLOW_SYMLINKS);
+$l = new RecursiveIteratorIterator($dirOrIterator);
+
+// Iterate over each element in the path, and create a map of
+// template name => filename, where the filename is relative to the view path
+$map = new stdClass;
+foreach ($l as $file) {
+    /* @var $file SplFileInfo */
+    if (!$file->isFile() || !preg_match('/^' . $fileExtensions . '$/', $file->getExtension())) {
+        continue;
+    }
+    $filename  = str_replace($libraryPath . '/', '', str_replace(DIRECTORY_SEPARATOR, '/', $file->getPath()) . '/' . $file->getFilename());
+
+    // Add in relative path to library
+    $filename = $relativePathForMap . $filename;
+    $baseName = $file->getBasename('.' . pathinfo($file->getFilename(), PATHINFO_EXTENSION));
+    $mapName  = str_replace(str_replace(DIRECTORY_SEPARATOR, '/', realpath($viewPath)) . '/', '', str_replace(DIRECTORY_SEPARATOR, '/', $file->getPath()) . '/' . $baseName);
+    $map->{$mapName} = $filename;
+}
+
+// Create a file with the map.
+
+if ($appending && file_exists($output) && is_array(include $output)) {
+    // Append mode and the output file already exists: retrieve its
+    // content and merges with the new map
+    // Remove the last line as it is the end of the array, and we want to
+    // append our new templates
+    $content = file($output, FILE_IGNORE_NEW_LINES);
+    array_pop($content);
+    $content = implode(PHP_EOL, $content) . PHP_EOL;
+} else {
+    // Write mode or the file does not exists: create a new file
+    // Stupid syntax highlighters make separating < from PHP declaration necessary
+    $content = '<' . "?php" . PHP_EOL
+        . '// Generated by Zend\View\'s ./bin/templatemap_generator.php'  . PHP_EOL
+        . 'return array(' . PHP_EOL;
+}
+
+// Process the template map as a string before inserting it to the output file
+
+$mapExport = var_export((array) $map, true);
+
+// Prefix with __DIR__
+$mapExport = preg_replace("#(=> ')#", "=> __DIR__ . '/", $mapExport);
+
+// Fix \' strings from injected DIRECTORY_SEPARATOR usage in iterator_apply op
+$mapExport = str_replace("\\'", "'", $mapExport);
+
+// Remove unnecessary double-backslashes
+$mapExport = str_replace('\\\\', '\\', $mapExport);
+
+// Remove "array ("
+$mapExport = str_replace('array (', '', $mapExport);
+
+// Align "=>" operators to match coding standard
+preg_match_all('(\n\s+([^=]+)=>)', $mapExport, $matches, PREG_SET_ORDER);
+$maxWidth = 0;
+
+foreach ($matches as $match) {
+    $maxWidth = max($maxWidth, strlen($match[1]));
+}
+
+$mapExport = preg_replace_callback('(\n\s+([^=]+)=>)', function ($matches) use ($maxWidth) {
+    return PHP_EOL . '    ' . $matches[1] . str_repeat(' ', $maxWidth - strlen($matches[1])) . '=>';
+}, $mapExport);
+
+// Trim the content
+$mapExport = trim($mapExport, "\n");
+
+// Append the map to the file, close the array and write a new line
+$content .= $mapExport . ';' . PHP_EOL;
+
+// Write the contents to disk
+file_put_contents($output, $content);
+
+if (!$usingStdout) {
+    echo "Wrote templatemap file to '" . realpath($output) . "'" . PHP_EOL;
+}

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -61,7 +61,7 @@ EOH;
 
 // Called without arguments
 if ($argc < 2) {
-    echo $help;
+    fwrite(STDERR, $help);
     exit(2);
 }
 
@@ -73,7 +73,7 @@ if (in_array($argv[1], ['-h', '--help'], true)) {
 
 // Not enough arguments
 if ($argc < 3) {
-    echo $help;
+    fwrite(STDERR, $help);
     exit(2);
 }
 

--- a/bin/templatemap_generator.php
+++ b/bin/templatemap_generator.php
@@ -98,7 +98,7 @@ $entries = array_map(function ($file) use ($basePath, $realPath) {
         : $template;
 
     $template = preg_replace('#^\.*/#', '', $template);
-    $file     = sprintf('__DIR__ . \'%s\'', $file);
+    $file     = sprintf('__DIR__ . \'/%s\'', $file);
 
     return sprintf("    '%s' => %s,\n", $template, $file);
 }, $files);

--- a/composer.json
+++ b/composer.json
@@ -70,5 +70,8 @@
         "psr-4": {
             "ZendTest\\View\\": "test/"
         }
-    }
+    },
+    "bin": [
+        "bin/templatemap_generator.php"
+    ]
 }


### PR DESCRIPTION
This patch builds on #65, incorporating the feedback I provided via [a comment on the original ZendSkeletonApplication issue](https://github.com/zendframework/ZendSkeletonApplication/pull/340#discussion_r67228492) that began the change.

Essentially, I want to avoid adding zend-console as a dependency of zend-view.

What this patch does is remove the usage of `Zend\Console\Getopt`, and simplifies the usage to a single, narrow use case: `cd module/ModuleName/config && ../../../vendor/bin/templatemap_generator.php ../view ../view/**/*.phtml > template_map.config.php`. This command will create the file `module/ModuleName/config/template_map.config.php`, which will map templates to `.phtml` view scripts located in `module/ModuleName/view/`. Users would then define the template map entry in `module.config.php` as follows:

```php
'template_map' => include __DIR__ . '/template_map.config.php',
```

This allows regeneration of the template map on-demand using the same command, without requiring parsing and updating the main module configuration file.

I believe this is the 80% use case, and developers can build out their own solutions for anything needing more customization.

Full usage is:

```text
Generate template maps.

Usage:

templatemap_generator.php [-h|--help] templatepath <files...>

--help|-h                    Print this usage message.
templatepath                 Path to templates relative to current working
                             path; used to identify what to strip from
                             template names. Must be a directory.
<files...>                   List of files to include in the template
                             map, relative to the current working path.

The script assumes that paths included in the template map are relative
to the current working directory.

The script will output a PHP script that will return the template map
on successful completion. You may save this to a file using standard
piping operators; use ">" to write to/ovewrite a file, ">>" to append
to a file (which may have unexpected and/or intended results; you will
need to edit the file after generation to ensure it contains valid
PHP).

If only the templatepath argument is provided, the script will look for
all .phtml files under that directory, creating a map for you.

If you want to specify a specific list of files -- for instance, if you
are using an extension other than .phtml -- we recommend one of the
following constructs:

For any shell, you can pipe the results of `find`:

    $(find ../view -name '*.phtml')

For zsh, or bash where you have enabled globstar (`shopt  -s globstar` in
either your bash profile or from within your terminal):

    ../view/**/*.phtml

We recommend you then include the generated file within your module
configuration:

  'template_map' => include __DIR__ . '/template_map.config.php',

Examples:

  # Using only a templatepath argument, which will match any .phtml
  # files found under the provided path:
  $ cd module/Application/config/
  $ ../../../vendor/bin/templatemap_generator.php ../view > template_map.config.php

  # Create a template_map.config.php file in the Application module's
  # config directory, relative to the view directory, and only containing
  # .html.php files; overwrite any existing files:
  $ cd module/Application/config/
  $ ../../../vendor/bin/templatemap_generator.php ../view ../view/**/*.html.php > template_map.config.php

  # OR using find:
  $ ../../../vendor/bin/templatemap_generator.php \
  > ../view \
  > $(find ../view -name '*.html.php') > template_map.config.phpp
```