### PR TITLE
Provide forward compatibility with v3 where functionality is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ cache:
 env:
   global:
     - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
-    - SITE_URL: https://zendframework.github.io/zend-view
-    - GH_USER_NAME: "Matthew Weier O'Phinney"
-    - GH_USER_EMAIL: matthew@weierophinney.net
-    - GH_REF: github.com/zendframework/zend-view.git
+    - LATEST_DEPS="zendframework/zend-mvc-plugin-flashmessenger zendframework/zend-mvc-i18n zendframework/zend-mvc-console"
+    - SITE_URL=https://zendframework.github.io/zend-view
+    - GH_USER_NAME="Matthew Weier O'Phinney"
+    - GH_USER_EMAIL=matthew@weierophinney.net
+    - GH_REF=github.com/zendframework/zend-view.git
     - secure: "kF7z5CxnrD/lsX9sP1+SYLKm1HdT/u1F0xovlyT9fDWrz+X4DBe8Oybzk6UX5HKXQvdhVTfAbHoWhFxFrkcRKrtaEOltk68bYFgnSOYhrK5EhZz6CHqN2j1MtT6FRfdlSOi6OECvCE3wd8nYHixxEviIZyB3L5+H39FOiu5Zi+eJT/myp6IuBO6lQfnSgqKdvuQXlfWSn9VGQJztX6ea2U89eM/TAVWEwbhLAJOsOejkvAy2lvYhIZpvSEkFm9jSp3/JOw8MFljG8UEDZUkpj+zba5/vqzM8thTTbybhAIBF7wNeMNrAeFBnrPz5KDPEQYYG8NG4we6F7GvbevvBz+ej5OJPXx/ulhMiEWKN1qEmQHZ3Gl0kG0O+TgXfqLErbCNn4MLP/K0Avar03m9bvXtaTA5Yqde0rIdspjwdxmKi0OI76UnGETMDyWuXbHkRfhs54sUEOBUdM3dz5lXhlSWPCTlQCgzkVqlgTL5b8b1u7YKpkwJAFSXMhhJBycFCNCfqAy10l2wjgvhXhLgPHle7sSwYR6SMVzkjj59P1UKc2yrxkwl/S7cqrbaeGSGjDv/QVMLtBL3OLqXwIaKy3POF2gQJhFXdrmGzDOADyCbEXVUYve5pQOmT1RdVHaHiT7AmZXEQibR1DW2zzU9eX94XpK9LKzlSzUOtYT8LNNA="
 
 matrix:
@@ -78,7 +79,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
-  - if [[ $DEPS == 'latest' ]]; then travis_retry composer require --dev --no-update $COMPOSER_ARGS zendframework/zend-mvc-plugin-flashmessenger ; fi
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer require --dev --no-update $COMPOSER_ARGS $LATEST_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - travis_retry composer install $COMPOSER_ARGS

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,7 @@ before_install:
   - if [[ $EXECUTE_TEST_COVERALLS == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
 
 install:
+  - if [[ $DEPS == 'latest' ]]; then travis_retry composer require --dev --no-update $COMPOSER_ARGS zendframework/zend-mvc-plugin-flashmessenger ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
   - travis_retry composer install $COMPOSER_ARGS

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "zendframework/zend-json": "^2.6.1",
         "zendframework/zend-log": "^2.7",
         "zendframework/zend-modulemanager": "^2.7.1",
-        "zendframework/zend-mvc": "^2.7",
+        "zendframework/zend-mvc": "^2.7 || ^3.0",
         "zendframework/zend-navigation": "^2.5",
         "zendframework/zend-paginator": "^2.5",
         "zendframework/zend-permissions-acl": "^2.6",

--- a/src/Helper/FlashMessenger.php
+++ b/src/Helper/FlashMessenger.php
@@ -7,12 +7,17 @@
 
 namespace Zend\View\Helper;
 
+use Zend\Mvc\Controller\Plugin\FlashMessenger as V2PluginFlashMessenger;
 use Zend\Mvc\Plugin\FlashMessenger\FlashMessenger as PluginFlashMessenger;
+use Zend\View\Exception\InvalidArgumentException;
 
 /**
  * Helper to proxy the plugin flash messenger
  *
  * Duck-types against Zend\I18n\Translator\TranslatorAwareInterface.
+ *
+ * @deprecated This helper will be removed in version 3.0 of this component.
+ *     At that time, it will be available in zendframework/zend-mvc-plugin-flashmessenger.
  */
 class FlashMessenger extends AbstractHelper
 {
@@ -21,14 +26,16 @@ class FlashMessenger extends AbstractHelper
     /**
      * Default attributes for the open format tag
      *
+     * @todo For version 3, have the keys reference the class constants in the
+     *     FlashMessenger plugin.
      * @var array
      */
     protected $classMessages = [
-        PluginFlashMessenger::NAMESPACE_INFO => 'info',
-        PluginFlashMessenger::NAMESPACE_ERROR => 'error',
-        PluginFlashMessenger::NAMESPACE_SUCCESS => 'success',
-        PluginFlashMessenger::NAMESPACE_DEFAULT => 'default',
-        PluginFlashMessenger::NAMESPACE_WARNING => 'warning',
+        'info'    => 'info',
+        'error'   => 'error',
+        'success' => 'success',
+        'default' => 'default',
+        'warning' => 'warning',
     ];
 
     /**
@@ -57,7 +64,7 @@ class FlashMessenger extends AbstractHelper
     /**
      * Flash messenger plugin
      *
-     * @var PluginFlashMessenger
+     * @var V2PluginFlashMessenger|PluginFlashMessenger
      */
     protected $pluginFlashMessenger;
 
@@ -65,7 +72,7 @@ class FlashMessenger extends AbstractHelper
      * Returns the flash messenger plugin controller
      *
      * @param  string|null $namespace
-     * @return FlashMessenger|PluginFlashMessenger
+     * @return FlashMessenger|V2PluginFlashMessenger|PluginFlashMessenger
      */
     public function __invoke($namespace = null)
     {
@@ -98,7 +105,7 @@ class FlashMessenger extends AbstractHelper
      * @param  null|bool $autoEscape
      * @return string
      */
-    public function render($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = [], $autoEscape = null)
+    public function render($namespace = 'default', array $classes = [], $autoEscape = null)
     {
         $flashMessenger = $this->getPluginFlashMessenger();
         $messages = $flashMessenger->getMessagesFromNamespace($namespace);
@@ -113,7 +120,7 @@ class FlashMessenger extends AbstractHelper
      * @param  bool|null $autoEscape
      * @return string
      */
-    public function renderCurrent($namespace = PluginFlashMessenger::NAMESPACE_DEFAULT, array $classes = [], $autoEscape = null)
+    public function renderCurrent($namespace = 'default', array $classes = [], $autoEscape = null)
     {
         $flashMessenger = $this->getPluginFlashMessenger();
         $messages = $flashMessenger->getCurrentMessagesFromNamespace($namespace);
@@ -130,7 +137,7 @@ class FlashMessenger extends AbstractHelper
      * @return string
      */
     protected function renderMessages(
-        $namespace = PluginFlashMessenger::NAMESPACE_DEFAULT,
+        $namespace = 'default',
         array $messages = [],
         array $classes = [],
         $autoEscape = null
@@ -144,7 +151,7 @@ class FlashMessenger extends AbstractHelper
             if (isset($this->classMessages[$namespace])) {
                 $classes = $this->classMessages[$namespace];
             } else {
-                $classes = $this->classMessages[PluginFlashMessenger::NAMESPACE_DEFAULT];
+                $classes = $this->classMessages['default'];
             }
             $classes = [$classes];
         }
@@ -282,11 +289,24 @@ class FlashMessenger extends AbstractHelper
     /**
      * Set the flash messenger plugin
      *
-     * @param  PluginFlashMessenger $pluginFlashMessenger
+     * @param  V2PluginFlashMessenger|PluginFlashMessenger $pluginFlashMessenger
      * @return FlashMessenger
+     * @throws InvalidArgumentException for an invalid $pluginFlashMessenger
      */
-    public function setPluginFlashMessenger(PluginFlashMessenger $pluginFlashMessenger)
+    public function setPluginFlashMessenger($pluginFlashMessenger)
     {
+        if (! $pluginFlashMessenger instanceof V2PluginFlashMessenger
+            && ! $pluginFlashMessenger instanceof PluginFlashMessenger
+        ) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects either a %s or %s instance; received %s',
+                __METHOD__,
+                V2PluginFlashMessenger::class,
+                PluginFlashMessenger::class,
+                (is_object($pluginFlashMessenger) ? get_class($pluginFlashMessenger) : gettype($pluginFlashMessenger))
+            ));
+        }
+
         $this->pluginFlashMessenger = $pluginFlashMessenger;
         return $this;
     }
@@ -294,12 +314,16 @@ class FlashMessenger extends AbstractHelper
     /**
      * Get the flash messenger plugin
      *
-     * @return PluginFlashMessenger
+     * @return V2PluginFlashMessenger|PluginFlashMessenger
      */
     public function getPluginFlashMessenger()
     {
         if (null === $this->pluginFlashMessenger) {
-            $this->setPluginFlashMessenger(new PluginFlashMessenger());
+            $this->setPluginFlashMessenger(
+                class_exists(PluginFlashMessenger::class)
+                ? new PluginFlashMessenger()
+                : new V2PluginFlashMessenger()
+            );
         }
 
         return $this->pluginFlashMessenger;

--- a/test/Helper/Navigation/AbstractTest.php
+++ b/test/Helper/Navigation/AbstractTest.php
@@ -138,7 +138,7 @@ abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 
         (new ServiceManagerConfig())->configureServiceManager($sm);
 
-        if (class_exists(RouterConfigProvider::class)) {
+        if (! class_exists(V2RouteMatch::class) && class_exists(RouterConfigProvider::class)) {
             $routerConfig = new Config((new RouterConfigProvider())->getDependencyConfig());
             $routerConfig->configureServiceManager($sm);
         }

--- a/test/Helper/UrlIntegrationTest.php
+++ b/test/Helper/UrlIntegrationTest.php
@@ -68,7 +68,7 @@ class UrlIntegrationTest extends \PHPUnit_Framework_TestCase
         $this->serviceManager = new ServiceManager();
         (new ServiceManagerConfig($serviceConfig))->configureServiceManager($this->serviceManager);
 
-        if (class_exists(RouterConfigProvider::class)) {
+        if (! class_exists(V2HttpRoute\Literal::class) && class_exists(RouterConfigProvider::class)) {
             $routerConfig = new Config((new RouterConfigProvider())->getDependencyConfig());
             $routerConfig->configureServiceManager($this->serviceManager);
         }

--- a/test/Helper/UrlTest.php
+++ b/test/Helper/UrlTest.php
@@ -52,29 +52,30 @@ class UrlTest extends \PHPUnit_Framework_TestCase
      */
     protected function setUp()
     {
-        $this->routeMatchType = class_exists(NextGenRouteMatch::class)
-            ? NextGenRouteMatch::class
-            : RouteMatch::class;
+        $this->routeMatchType = class_exists(RouteMatch::class)
+            ? RouteMatch::class
+            : NextGenRouteMatch::class;
 
-        $this->literalRouteType = class_exists(NextGenLiteralRoute::class)
-            ? NextGenLiteralRoute::class
-            : LiteralRoute::class;
+        $this->literalRouteType = class_exists(LiteralRoute::class)
+            ? LiteralRoute::class
+            : NextGenLiteralRoute::class;
 
-        $this->segmentRouteType = class_exists(NextGenSegmentRoute::class)
-            ? NextGenSegmentRoute::class
-            : SegmentRoute::class;
+        $this->segmentRouteType = class_exists(SegmentRoute::class)
+            ? SegmentRoute::class
+            : NextGenSegmentRoute::class;
 
-        $this->treeRouteStackType = class_exists(NextGenTreeRouteStack::class)
-            ? NextGenTreeRouteStack::class
-            : TreeRouteStack::class;
+        $this->treeRouteStackType = class_exists(TreeRouteStack::class)
+            ? TreeRouteStack::class
+            : NextGenTreeRouteStack::class;
 
-        $this->wildcardRouteType = class_exists(NextGenWildcardRoute::class)
-            ? NextGenWildcardRoute::class
-            : WildcardRoute::class;
+        $this->wildcardRouteType = class_exists(WildcardRoute::class)
+            ? WildcardRoute::class
+            : NextGenWildcardRoute::class;
 
-        $routerClass = class_exists(NextGenRouter::class)
-            ? NextGenRouter::class
-            : Router::class;
+        $routerClass = class_exists(Router::class)
+            ? Router::class
+            : NextGenRouter::class;
+
         $router = new $routerClass();
         $router->addRoute('home', [
             'type' => $this->literalRouteType,

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -11,8 +11,9 @@ namespace ZendTest\View;
 
 use PHPUnit_Framework_TestCase as TestCase;
 use ReflectionProperty;
-use Zend\Mvc\Controller\Plugin\FlashMessenger;
+use Zend\Mvc\Controller\Plugin\FlashMessenger as V2FlashMessenger;
 use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
+use Zend\Mvc\Plugin\FlashMessenger\FlashMessenger;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
@@ -31,7 +32,9 @@ class HelperPluginManagerCompatibilityTest extends TestCase
             $factories['ControllerPluginManager'] = function ($services, $name, $options) {
                 return new ControllerPluginManager($services, [
                     'invokables' => [
-                        'flashmessenger' => FlashMessenger::class,
+                        'flashmessenger' => class_exists(FlashMessenger::class)
+                            ? FlashMessenger::class
+                            : V2FlashMessenger::class,
                     ],
                 ]);
             };


### PR DESCRIPTION
Updates zend-view to be forwards compatible with zend-mvc v3.

## UrlHelper

The UrlHelper tests were previously using typehints against the zend-mvc v2 router in some locations. This patch provides updates to the test to detect which router version is present, as well as which route classes, so it can test correctly across both router versions.

## Navigation helpers

The navigation helper tests were:

- hardcoding against the v2 RouteMatch
- not taking into account that route services move to the zend-router package when zend-mvc v3 is present.

They have been updated to resolve this, and now pass against both versions.

## FlashMessenger

Updates the FlashMessenger to be forwards compatible with zendframework/zend-mvc-plugin-flashmessenger, while retaining compatibility with zend-mvc 2.7. This required:

- Removing references to class constants defined in the FlashMessenger MVC plugin; this means temporarily hardcoding the values in the helper, and resulted in a TODO item to re-introduce them for version 3.
- Removing typehints for the FlashMessenger MVC plugin; when required, we now test against both the v2 and v3 class name to validate.
- Deprecating the helper for version 3.0.

This PR supercedes #78.