### PR TITLE
Typo viewHelperManager > ViewHelperManager

### DIFF
--- a/doc/book/helpers/head-title.md
+++ b/doc/book/helpers/head-title.md
@@ -56,7 +56,7 @@ class Module
         $siteName   = 'Zend Framework';
 
         // Getting the view helper manager from the application service manager
-        $viewHelperManager = $e->getApplication()->getServiceManager()->get('viewHelperManager');
+        $viewHelperManager = $e->getApplication()->getServiceManager()->get('ViewHelperManager');
 
         // Getting the headTitle helper from the view helper manager
         $headTitleHelper = $viewHelperManager->get('headTitle');


### PR DESCRIPTION
this results in actually finding the ViewHelperManager using lowercase will result in 
Uncaught Zend\ServiceManager\Exception\ServiceNotFoundException: Unable to resolve service "viewHelperManager" to a factory;
