### PR TITLE
DOCS: Dont mention the inspection of the Accept HTTP Header

### DIFF
--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -583,16 +583,12 @@ within your application.
 - `Zend\View\Strategy\PhpRendererStrategy`. This strategy is a "catch-all" in
   that it will always return the `Zend\View\Renderer\PhpRenderer` and populate
   the Response body with the results of rendering.
-- `Zend\View\Strategy\JsonStrategy`. This strategy inspects the `Accept` HTTP
-  request header, if present, and determines if the client has indicated it
-  accepts an `application/json` response. If so, it will return the
+- `Zend\View\Strategy\JsonStrategy`. This strategy will return the
   `Zend\View\Renderer\JsonRenderer`, and populate the Response body with the
   JSON value returned, as well as set a `Content-Type` header with a value of
   `application/json`.
-- `Zend\View\Strategy\FeedStrategy`. This strategy inspects the `Accept` HTTP
-  header, if present, and determines if the client has indicated it accepts
-  either an `application/rss+xml` or `application/atom+xml` response. If so, it
-  will return the `Zend\View\Renderer\FeedRenderer`, setting the feed type to
+- `Zend\View\Strategy\FeedStrategy`. This strategy will return the 
+  `Zend\View\Renderer\FeedRenderer`, setting the feed type to
   either "rss" or "atom", based on what was matched. Its Response strategy will
   populate the Response body with the generated feed, as well as set a
   `Content-Type` header with the appropriate value based on feed type.

--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -635,7 +635,7 @@ class Module
 
 The above will register the `JsonStrategy` with the "render" event, such that it
 executes prior to the `PhpRendererStrategy`, and thus ensure that a JSON payload
-is created when the controller returns an `JsonModel`.
+is created when the controller returns a `JsonModel`.
 
 You could also use the module configuration to add the strategies:
 ```php
@@ -651,8 +651,9 @@ class Module implements \Zend\ModuleManager\Feature\ConfigProviderInterface
     public function getConfig()
     {
         return [
-            // ...
+            /* ... */
             'view_manager' => [
+                /* ... */
                 'strategies' => [
                     'ViewJsonStrategy',
                 ],
@@ -726,7 +727,7 @@ class MyController extends \Zend\Mvc\Controller\AbstractActionController
      */
     public function listAction()
     {
-        $items = /* ... get items .. .*/;
+        $items = /* ... get items ... */;
         $viewModel = new \Zend\View\Model\ViewModel();
         $viewModel->setVariable('items', $items);
         return $viewModel;
@@ -737,7 +738,7 @@ class MyController extends \Zend\Mvc\Controller\AbstractActionController
      */
     public function listJsonAction()
     {
-        $items = /* ... get items .. .*/;
+        $items = /* ... get items ... */;
         $viewModel = new \Zend\View\Model\JsonModel();
         $viewModel->setVariable('items', $items);
         return $viewModel;
@@ -748,7 +749,7 @@ class MyController extends \Zend\Mvc\Controller\AbstractActionController
      */
     public function listFeedAction()
     {
-        $items = /* ... get items .. .*/;
+        $items = /* ... get items ... */;
         $viewModel = new \Zend\View\Model\FeedModel();
         $viewModel->setVariable('items', $items);
         return $viewModel;
@@ -756,5 +757,5 @@ class MyController extends \Zend\Mvc\Controller\AbstractActionController
 }
 ```
 
-Or you could switch the `ViewModel` dynamically based on the "Accept" HTTP Header: 
-[Zend-Mvc: AcceptableViewModelSelector Plugin](http://zendframework.github.io/zend-mvc/plugins/#acceptableviewmodelselector-plugin).
+Or you could switch the `ViewModel` dynamically based on the "Accept" HTTP Header with the 
+[Zend-Mvc-Plugin AcceptableViewModelSelector](http://zendframework.github.io/zend-mvc/plugins/#acceptableviewmodelselector-plugin).

--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -534,13 +534,15 @@ priority. Typically, you will register this during the bootstrap event.
 ```php
 namespace Content;
 
+use Zend\Mvc\MvcEvent;
+
 class Module
 {
     /**
-     * @param  \Zend\Mvc\MvcEvent $e The MvcEvent instance
+     * @param  MvcEvent $e The MvcEvent instance
      * @return void
      */
-    public function onBootstrap($e)
+    public function onBootstrap(MvcEvent $e)
     {
         // Register a dispatch event
         $app = $e->getParam('application');
@@ -548,10 +550,10 @@ class Module
     }
 
     /**
-     * @param  \Zend\Mvc\MvcEvent $e The MvcEvent instance
+     * @param  MvcEvent $e The MvcEvent instance
      * @return void
      */
-    public function setLayout($e)
+    public function setLayout(MvcEvent $e)
     {
         $matches    = $e->getRouteMatch();
         $controller = $matches->getParam('controller');
@@ -602,13 +604,15 @@ register the `JsonStrategy`:
 ```php
 namespace Application;
 
+use Zend\Mvc\MvcEvent;
+
 class Module
 {
     /**
-     * @param  \Zend\Mvc\MvcEvent $e The MvcEvent instance
+     * @param  MvcEvent $e The MvcEvent instance
      * @return void
      */
-    public function onBootstrap($e)
+    public function onBootstrap(MvcEvent $e)
     {
         // Register a "render" event, at high priority (so it executes prior
         // to the view attempting to render)
@@ -617,10 +621,10 @@ class Module
     }
 
     /**
-     * @param  \Zend\Mvc\MvcEvent $e The MvcEvent instance
+     * @param  MvcEvent $e The MvcEvent instance
      * @return void
      */
-    public function registerJsonStrategy($e)
+    public function registerJsonStrategy(MvcEvent $e)
     {
         $app          = $e->getTarget();
         $locator      = $app->getServiceManager();
@@ -641,7 +645,9 @@ You could also use the module configuration to add the strategies:
 ```php
 namespace Application;
 
-class Module implements \Zend\ModuleManager\Feature\ConfigProviderInterface
+use Zend\ModuleManager\Feature\ConfigProviderInterface;
+
+class Module implements ConfigProviderInterface
 {
     /**
      * Returns configuration to merge with application configuration
@@ -671,13 +677,15 @@ the layout for a specific module:
 ```php
 namespace Application;
 
+use Zend\Mvc\MvcEvent;
+
 class Module
 {
     /**
-     * @param  \Zend\Mvc\MvcEvent $e The MvcEvent instance
+     * @param  MvcEvent $e The MvcEvent instance
      * @return void
      */
-    public function onBootstrap($e)
+    public function onBootstrap(MvcEvent $e)
     {
         // Register a render event
         $app = $e->getParam('application');
@@ -685,10 +693,10 @@ class Module
     }
 
     /**
-     * @param  \Zend\Mvc\MvcEvent $e The MvcEvent instance
+     * @param  MvcEvent $e The MvcEvent instance
      * @return void
      */
-    public function registerJsonStrategy($e)
+    public function registerJsonStrategy(MvcEvent $e)
     {
         $matches    = $e->getRouteMatch();
         $controller = $matches->getParam('controller');
@@ -720,7 +728,12 @@ If you successfully registered the Strategy you need to use the appropriate `Vie
 ```php
 namespace Application;
 
-class MyController extends \Zend\Mvc\Controller\AbstractActionController
+use Zend\Mvc\Controller\AbstractActionController;
+use Zend\View\Model\ViewModel;
+use Zend\View\Model\JsonModel;
+use Zend\View\Model\FeedModel;
+
+class MyController extends AbstractActionController
 {
     /**
      * Lists the items as HTML
@@ -728,7 +741,7 @@ class MyController extends \Zend\Mvc\Controller\AbstractActionController
     public function listAction()
     {
         $items = /* ... get items ... */;
-        $viewModel = new \Zend\View\Model\ViewModel();
+        $viewModel = new ViewModel();
         $viewModel->setVariable('items', $items);
         return $viewModel;
     }
@@ -739,7 +752,7 @@ class MyController extends \Zend\Mvc\Controller\AbstractActionController
     public function listJsonAction()
     {
         $items = /* ... get items ... */;
-        $viewModel = new \Zend\View\Model\JsonModel();
+        $viewModel = new JsonModel();
         $viewModel->setVariable('items', $items);
         return $viewModel;
     }
@@ -750,7 +763,7 @@ class MyController extends \Zend\Mvc\Controller\AbstractActionController
     public function listFeedAction()
     {
         $items = /* ... get items ... */;
-        $viewModel = new \Zend\View\Model\FeedModel();
+        $viewModel = new FeedModel();
         $viewModel->setVariable('items', $items);
         return $viewModel;
     }

--- a/src/Strategy/FeedStrategy.php
+++ b/src/Strategy/FeedStrategy.php
@@ -43,8 +43,7 @@ class FeedStrategy extends AbstractListenerAggregate
     }
 
     /**
-     * Detect if we should use the FeedRenderer based on model type and/or
-     * Accept header
+     * Detect if we should use the FeedRenderer based on model type
      *
      * @param  ViewEvent $e
      * @return null|FeedRenderer

--- a/src/Strategy/JsonStrategy.php
+++ b/src/Strategy/JsonStrategy.php
@@ -81,8 +81,7 @@ class JsonStrategy extends AbstractListenerAggregate
     }
 
     /**
-     * Detect if we should use the JsonRenderer based on model type and/or
-     * Accept header
+     * Detect if we should use the JsonRenderer based on model type
      *
      * @param  ViewEvent $e
      * @return null|JsonRenderer


### PR DESCRIPTION
The View Strategies are mentioning (in the code and in the docs) that they are inspecting the "Accept" HTTP header and determine if they are going to inject their renderer and response.

But in fact, they dont do that. They just test if the View Model is an instanceof their ViewModel (JsonModel and FeedModel). I trusted the documentation on that and spent a lot of time wondering why it doesnt work... :(

I've removed every (wrong) mentioning of the inspection of the "Accept" header from the php-docs and the md docs. I've left in the (correct) sections in the quick-start on how to inspect the "Accept" header and set the correct strategy accordingly.

There should be no changes in behavior at all because only documentation was changed.
