### PR TITLE
Allow integrity & crossorigin on head srcript/link

### DIFF
--- a/doc/book/helpers/head-link.md
+++ b/doc/book/helpers/head-link.md
@@ -8,10 +8,10 @@ elements for later retrieval and output in your layout script.
 The `HeadLink` helper has special methods for adding stylesheet links to its
 stack:
 
-- `appendStylesheet($href, $media, $conditionalStylesheet, $extras)`
-- `offsetSetStylesheet($index, $href, $media, $conditionalStylesheet, $extras)`
-- `prependStylesheet($href, $media, $conditionalStylesheet, $extras)`
-- `setStylesheet($href, $media, $conditionalStylesheet, $extras)`
+- `appendStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
+- `offsetSetStylesheet($index, $href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
+- `prependStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
+- `setStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
 
 The `$media` value defaults to 'screen', but may be any valid media value.
 `$conditionalStylesheet` is a string or boolean `false`, and will be used at
@@ -22,10 +22,10 @@ extra values that you want to be added to the tag.
 Additionally, the `HeadLink` helper has special methods for adding 'alternate'
 links to its stack:
 
-- `appendAlternate($href, $type, $title, $extras)`
-- `offsetSetAlternate($index, $href, $type, $title, $extras)`
-- `prependAlternate($href, $type, $title, $extras)`
-- `setAlternate($href, $type, $title, $extras)`
+- `appendAlternate($href, $type, $title, $extras = array())`
+- `offsetSetAlternate($index, $href, $type, $title, $extras = array())`
+- `prependAlternate($href, $type, $title, $extras = array())`
+- `setAlternate($href, $type, $title, $extras = array())`
 
 The `headLink()` helper method allows specifying all attributes necessary for a
 `<link>` element, and allows you to also specify placement: whether the

--- a/doc/book/helpers/head-link.md
+++ b/doc/book/helpers/head-link.md
@@ -8,10 +8,10 @@ elements for later retrieval and output in your layout script.
 The `HeadLink` helper has special methods for adding stylesheet links to its
 stack:
 
-- `appendStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
-- `offsetSetStylesheet($index, $href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
-- `prependStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
-- `setStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())`
+- `appendStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = [])`
+- `offsetSetStylesheet($index, $href, $media = 'screen', $conditionalStylesheet = '', $extras = [])`
+- `prependStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = [])`
+- `setStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = [])`
 
 The `$media` value defaults to 'screen', but may be any valid media value.
 `$conditionalStylesheet` is a string or boolean `false`, and will be used at
@@ -22,10 +22,10 @@ extra values that you want to be added to the tag.
 Additionally, the `HeadLink` helper has special methods for adding 'alternate'
 links to its stack:
 
-- `appendAlternate($href, $type, $title, $extras = array())`
-- `offsetSetAlternate($index, $href, $type, $title, $extras = array())`
-- `prependAlternate($href, $type, $title, $extras = array())`
-- `setAlternate($href, $type, $title, $extras = array())`
+- `appendAlternate($href, $type, $title, $extras = [])`
+- `offsetSetAlternate($index, $href, $type, $title, $extras = [])`
+- `prependAlternate($href, $type, $title, $extras = [])`
+- `setAlternate($href, $type, $title, $extras = [])`
 
 The `headLink()` helper method allows specifying all attributes necessary for a
 `<link>` element, and allows you to also specify placement: whether the

--- a/doc/book/helpers/head-script.md
+++ b/doc/book/helpers/head-script.md
@@ -6,14 +6,14 @@ code. The `HeadScript` helper allows you to manage both.
 
 The `HeadScript` helper supports the following methods for setting and adding scripts:
 
-- `appendFile($src, $type = 'text/javascript', $attrs = array())`
-- `offsetSetFile($index, $src, $type = 'text/javascript', $attrs = array())`
-- `prependFile($src, $type = 'text/javascript', $attrs = array())`
-- `setFile($src, $type = 'text/javascript', $attrs = array())`
-- `appendScript($script, $type = 'text/javascript', $attrs = array())`
-- `offsetSetScript($index, $script, $type = 'text/javascript', $attrs = array())`
-- `prependScript($script, $type = 'text/javascript', $attrs = array())`
-- `setScript($script, $type = 'text/javascript', $attrs = array())`
+- `appendFile($src, $type = 'text/javascript', $attrs = [])`
+- `offsetSetFile($index, $src, $type = 'text/javascript', $attrs = [])`
+- `prependFile($src, $type = 'text/javascript', $attrs = [])`
+- `setFile($src, $type = 'text/javascript', $attrs = [])`
+- `appendScript($script, $type = 'text/javascript', $attrs = [])`
+- `offsetSetScript($index, $script, $type = 'text/javascript', $attrs = [])`
+- `prependScript($script, $type = 'text/javascript', $attrs = [])`
+- `setScript($script, $type = 'text/javascript', $attrs = [])`
 
 In the case of the `*File()` methods, `$src` is the remote location of the
 script to load; this is usually in the form of a URL or a path. For the

--- a/doc/book/helpers/head-script.md
+++ b/doc/book/helpers/head-script.md
@@ -86,7 +86,7 @@ The `HeadScript` helper is a concrete implementation of the
 > ### Arbitrary Attributes are Disabled by Default
 >
 > By default, `HeadScript` only will render `<script>` attributes that are blessed by the W3C.
-> These include `type`, `charset`, `defer`, `language`, and `src`. However, some JavaScript
+> These include `charset`, `crossorigin`, `defer`, `integrity`, `language`, `src`, and `type`. However, some JavaScript
 > frameworks, notably [Dojo](http://www.dojotoolkit.org/), utilize custom attributes in order to
 > modify behavior. To allow such attributes, you can enable them via the
 > `setAllowArbitraryAttributes()` method:

--- a/doc/book/helpers/head-style.md
+++ b/doc/book/helpers/head-style.md
@@ -12,10 +12,10 @@ The HTML `<style>` element is used to include CSS stylesheets inline in the HTML
 The `HeadStyle` helper supports the following methods for setting and adding stylesheet
 declarations:
 
-- `appendStyle($content, $attributes = array())`
-- `offsetSetStyle($index, $content, $attributes = array())`
-- `prependStyle($content, $attributes = array())`
-- `setStyle($content, $attributes = array())`
+- `appendStyle($content, $attributes = [])`
+- `offsetSetStyle($index, $content, $attributes = [])`
+- `prependStyle($content, $attributes = [])`
+- `setStyle($content, $attributes = [])`
 
 In all cases, `$content` is the actual CSS declarations. `$attributes` are any
 additional attributes you wish to provide to the `style` tag: lang, title,

--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -47,7 +47,9 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         'type',
         'title',
         'extras',
-        'itemprop'
+        'itemprop',
+        'crossorigin',
+        'integrity'
     ];
 
     /**

--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -19,14 +19,14 @@ use Zend\View\Exception;
  * @see http://www.w3.org/TR/xhtml1/dtds.html
  *
  * Creates the following virtual methods:
- * @method HeadLink appendStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())
- * @method HeadLink offsetSetStylesheet($index, $href, $media = 'screen', $conditionalStylesheet = '', $extras = array())
- * @method HeadLink prependStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())
- * @method HeadLink setStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = array())
- * @method HeadLink appendAlternate($href, $type, $title, $extras = array())
- * @method HeadLink offsetSetAlternate($index, $href, $type, $title, $extras = array())
- * @method HeadLink prependAlternate($href, $type, $title, $extras = array())
- * @method HeadLink setAlternate($href, $type, $title, $extras = array())
+ * @method HeadLink appendStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = [])
+ * @method HeadLink offsetSetStylesheet($index, $href, $media = 'screen', $conditionalStylesheet = '', $extras = [])
+ * @method HeadLink prependStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = [])
+ * @method HeadLink setStylesheet($href, $media = 'screen', $conditionalStylesheet = '', $extras = [])
+ * @method HeadLink appendAlternate($href, $type, $title, $extras = [])
+ * @method HeadLink offsetSetAlternate($index, $href, $type, $title, $extras = [])
+ * @method HeadLink prependAlternate($href, $type, $title, $extras = [])
+ * @method HeadLink setAlternate($href, $type, $title, $extras = [])
  */
 class HeadLink extends Placeholder\Container\AbstractStandalone
 {

--- a/src/Helper/HeadScript.php
+++ b/src/Helper/HeadScript.php
@@ -17,14 +17,14 @@ use Zend\View\Exception;
  * Helper for setting and retrieving script elements for HTML head section
  *
  * Allows the following method calls:
- * @method HeadScript appendFile($src, $type = 'text/javascript', $attrs = array())
- * @method HeadScript offsetSetFile($index, $src, $type = 'text/javascript', $attrs = array())
- * @method HeadScript prependFile($src, $type = 'text/javascript', $attrs = array())
- * @method HeadScript setFile($src, $type = 'text/javascript', $attrs = array())
- * @method HeadScript appendScript($script, $type = 'text/javascript', $attrs = array())
- * @method HeadScript offsetSetScript($index, $src, $type = 'text/javascript', $attrs = array())
- * @method HeadScript prependScript($script, $type = 'text/javascript', $attrs = array())
- * @method HeadScript setScript($script, $type = 'text/javascript', $attrs = array())
+ * @method HeadScript appendFile($src, $type = 'text/javascript', $attrs = [])
+ * @method HeadScript offsetSetFile($index, $src, $type = 'text/javascript', $attrs = [])
+ * @method HeadScript prependFile($src, $type = 'text/javascript', $attrs = [])
+ * @method HeadScript setFile($src, $type = 'text/javascript', $attrs = [])
+ * @method HeadScript appendScript($script, $type = 'text/javascript', $attrs = [])
+ * @method HeadScript offsetSetScript($index, $src, $type = 'text/javascript', $attrs = [])
+ * @method HeadScript prependScript($script, $type = 'text/javascript', $attrs = [])
+ * @method HeadScript setScript($script, $type = 'text/javascript', $attrs = [])
  */
 class HeadScript extends Placeholder\Container\AbstractStandalone
 {

--- a/src/Helper/HeadScript.php
+++ b/src/Helper/HeadScript.php
@@ -85,6 +85,7 @@ class HeadScript extends Placeholder\Container\AbstractStandalone
      */
     protected $optionalAttributes = [
         'charset',
+        'integrity',
         'crossorigin',
         'defer',
         'async',


### PR DESCRIPTION
I noticed more than a few cdn resources I use etc.. twitter bootstrap now include/encourage the use of the integrity attribute for script and link tags:  

"This integrity verification significantly reduces the risk that an attacker can substitute malicious content."   [https://www.w3.org/TR/SRI/](https://www.w3.org/TR/SRI/)

This request also includes the crossorigin attribute.