### PR TITLE
Render HTML5 meta charset at first position

### DIFF
--- a/src/Helper/HeadMeta.php
+++ b/src/Helper/HeadMeta.php
@@ -172,9 +172,18 @@ class HeadMeta extends Placeholder\Container\AbstractStandalone
         $items = [];
         $this->getContainer()->ksort();
 
+        $isHtml5 = $this->view->plugin('doctype')->isHtml5();
+
         try {
             foreach ($this as $item) {
-                $items[] = $this->itemToString($item);
+                $content = $this->itemToString($item);
+
+                if ($isHtml5 && $item->type == 'charset') {
+                    array_unshift($items, $content);
+                    continue;
+                }
+
+                $items[] = $content;
             }
         } catch (Exception\InvalidArgumentException $e) {
             trigger_error($e->getMessage(), E_USER_WARNING);

--- a/test/Helper/HeadMetaTest.php
+++ b/test/Helper/HeadMetaTest.php
@@ -403,6 +403,21 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
             $view->plugin('headMeta')->toString());
     }
 
+    public function testCharsetPosition()
+    {
+        $view = new View();
+        $view->plugin('doctype')->__invoke('HTML5');
+
+        $view->plugin('headMeta')
+            ->setProperty('description', 'foobar')
+            ->setCharset('utf-8');
+
+        $this->assertEquals(
+            '<meta charset="utf-8">' . PHP_EOL
+            . '<meta property="description" content="foobar">',
+            $view->plugin('headMeta')->toString());
+    }
+
      /**
      * @group ZF-9743
      */


### PR DESCRIPTION
W3C Markup Validation Service currently checks if a "meta charset" is configured at first position, because a HTML5 renderer needs to know what charset to use before the content.

Makes sense.

https://validator.w3.org/
http://stackoverflow.com/questions/18007771/how-do-i-fix-error-a-charset-attribute-on-a-meta-element-found-after-the-first