### PR TITLE
URL: use escaped argument separator for query

### DIFF
--- a/src/Helper/Url.php
+++ b/src/Helper/Url.php
@@ -103,6 +103,10 @@ class Url extends AbstractHelper
 
         $options['name'] = $name;
 
+        if (isset($options['query'])) {
+            $options['query'] = str_replace('+', '%20', http_build_query($options['query'], '', '&amp;'));
+        }
+
         return $this->router->assemble($params, $options);
     }
 

--- a/test/Helper/UrlTest.php
+++ b/test/Helper/UrlTest.php
@@ -252,4 +252,26 @@ class UrlTest extends \PHPUnit_Framework_TestCase
         $url->setRouteMatch($routeMatch);
         $this->assertAttributeSame($routeMatch, 'routeMatch', $url);
     }
+
+    public function testQueryStringInViewContextShouldUseEncodedSeparator()
+    {
+        $router = new $this->treeRouteStackType;
+        $router->addRoute('default', [
+            'type' => $this->segmentRouteType,
+            'options' => [
+                'route'    => '/:controller/:action',
+            ],
+        ]);
+
+        $helper = new UrlHelper();
+        $helper->setRouter($router);
+
+        $url = $helper->__invoke('default', ['controller' => 'ctrl', 'action' => 'act'], [
+            'query' => [
+                'first' => 'arg1',
+                'second' => 'arg2 withSpace',
+            ],
+        ]);
+        $this->assertSame('/ctrl/act?first=arg1&amp;second=arg2%20withSpace', $url);
+    }
 }


### PR DESCRIPTION
During the `assemble()` of a url in a TreeRouteStack router, the query part is passed to a Uri object:
https://github.com/zendframework/zend-router/blob/release-3.0.2/src/Http/TreeRouteStack.php#L393-L395
https://github.com/zendframework/zend-uri/blob/release-2.5.2/src/Uri.php#L788-L798

The Uri object uses the built-in php function `http_build_query`, which leans on the default `&` parameter to separate query arguments.

This is perfectly fine in an general abstract context, but is not correct in a view context where url should be encoded, and so should be its separator, resulting in a `&amp;`.