### PR TITLE
Fix: Case-insensitive method annotation for placeholder helper

### DIFF
--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -60,7 +60,7 @@ use Zend\View\Variables;
  * @method string paginationControl(\Zend\Paginator\Paginator $paginator = null, $scrollingStyle = null, $partial = null, $params = null)
  * @method string|\Zend\View\Helper\Partial partial($name = null, $values = null)
  * @method string partialLoop($name = null, $values = null)
- * @method \Zend\View\Helper\Placeholder\Container\AbstractContainer placeHolder($name = null)
+ * @method \Zend\View\Helper\Placeholder\Container\AbstractContainer placeholder($name = null)
  * @method string renderChildModel($child)
  * @method void renderToPlaceholder($script, $placeholder)
  * @method string serverUrl($requestUri = null)


### PR DESCRIPTION
This PR

* [x] fixes a case-insensitive annotation for the placeholder view helper on `PhpRenderer`

💁‍♂️ After updating from ZF2 to ZF3, view rendering fails with

```
Fatal error: Uncaught exception 'Zend\ServiceManager\Exception\ServiceNotFoundException' with message 'A plugin by the name "placeHolder" was not found in the plugin manager Zend\View\HelperPluginManager' in ~/project/vendor/zendframework/zend-servicemanager/src/AbstractPluginManager.php:131 

Stack trace: 

#0 ~/project/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(373): Zend\ServiceManager\AbstractPluginManager->get('placeHolder', NULL) 
#1 ~/project/vendor/zendframework/zend-view/src/Renderer/PhpRenderer.php(391): Zend\View\Renderer\PhpRenderer->plugin('placeHolder') 
#2 ~/project/module/Project/view/project/layout/default.phtml(67): Zend\View\Renderer\PhpRenderer->__call('placeHolder', Array) 
#3 ~/project/module/Project/view/project/layout/default.phtml(67): Zend\View\Renderer\PhpRenderer->placeHolder('bodyClass' in ~/project/vendor/zendframework/zend-servicemanager/src/AbstractPluginManager.php on line 131
```

When modifying the case, PhpStorm complains:

![screen shot 2017-01-29 at 23 51 55](https://cloud.githubusercontent.com/assets/605483/22408761/8ec9ca58-e67e-11e6-9d2b-b3f7e7897f98.png)
