### PR TITLE
Asset helper for various resourses.

### DIFF
--- a/doc/book/helpers/assets.md
+++ b/doc/book/helpers/assets.md
@@ -1,0 +1,160 @@
+# Assets
+
+The `Assets` helper allow to add various resourses to html page, such as .css, .js, etc.
+It can be configure in config files.
+For page performance optimisation assets can be placed in top or bottom of page (or elsewhere).
+Allow to build several link by one alias.
+Also can possible change layout decoration 'on fly'.
+
+## Basic Usage
+
+```php
+<?php
+// setting links in a view script:
+$this->assets()
+        ->add('http://com.com/foo.css')
+        ->add('/bar.css')
+        ->add('/bat.js');
+
+// rendering the links from the layout:
+echo $this->assets();
+?>
+```
+
+Output:
+
+```html
+<link href="http://com.com/foo.css" type="text/css">
+<link href="/bar.css" type="text/css">
+<script type="application/javascript" src="/bat.js"></script>
+```
+
+## Add assets to different positions on page
+
+```php
+<?php
+// setting links in a view script:
+$this->assets()
+        ->addHeader('/foo.css')
+        ->addFooter('/bar.css');
+
+// rendering the links from the layout:
+echo '<body>';
+    echo '<header>';
+    echo $this->assets()->renderHeader();
+    echo '</header>';
+    echo '<article> some content </article>';
+    echo '<footer>';
+    echo $this->assets()->renderFooter();
+    echo '</footer>';
+echo '</body>';
+?>
+```
+
+Output:
+
+```html
+<body>
+    <header>
+    <link href="/foo.css" type="text/css">
+    </header>
+    <article> some content </article>
+    <footer>
+    <link href="/bar.css" type="text/css">
+    </footer>
+</body>
+```
+
+## Using configurable assets
+
+```php
+<?php
+// section in config file:
+'assets_manager' => [
+    'assets' => [
+        'default' => [
+            'external.css' => [
+                'source' => 'http://com.com/foo.css',
+            ],
+            'foo.css' => [],
+            'several_assets' => [
+                'assets' => [
+                    'external.css',
+                    'bar.css',
+                    'bat.js' => [
+                        'attributes' => [
+                            'charset' => 'UTF-8',
+                        ],
+                    ],
+                ],
+            ],
+        ],
+    ],
+];
+?>
+```
+
+```php
+<?php
+// setting links in a view script:
+$this->assets()
+        ->add('foo.css')
+        ->add('several_assets');
+
+// rendering the links from the layout:
+echo $this->assets();
+?>
+```
+
+Output:
+
+```html
+<link href="/foo.css" type="text/css">
+<link href="http://com.com/foo.css" type="text/css">
+<link href="/bar.css" type="text/css">
+<script type="application/javascript" charset="UTF-8" src="/bat.js"></script>
+```
+
+## change layout decoration 'on fly'
+
+```php
+<?php
+// section in config file:
+'assets_manager' => [
+    'assets' => [
+        'default' => [
+            'layout.css' => 'foo.css',
+        ],
+        'my-theme' => [
+            'layout.css' => 'bar.css',
+        ],
+    ],
+];
+?>
+```
+
+```php
+<?php
+// setting links in a view script:
+$this->assets()->add('layout.css');
+if ('good weather') {
+  $this->assets()->getAssetsManager()->setCurrentGroup('my-theme');
+} else {
+  $this->assets()->getAssetsManager()->setCurrentGroup('default');
+}
+// rendering the links from the layout:
+echo $this->assets();
+?>
+```
+
+Default Output:
+
+```html
+<link href="/foo.css" type="text/css">
+```
+
+Output if good weather:
+
+```html
+<link href="/bar.css" type="text/css">
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -9,6 +9,7 @@ pages:
         - "The ViewEvent": view-event.md
     - Helpers:
         - Intro: helpers/intro.md
+        - Assets: helpers/assets.md
         - BasePath: helpers/base-path.md
         - Cycle: helpers/cycle.md
         - Doctype: helpers/doctype.md

--- a/src/Assets/AbstractAsset.php
+++ b/src/Assets/AbstractAsset.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets;
+
+abstract class AbstractAsset
+{
+    const PREFIX_DELIMITER = '::';
+
+    protected $name;
+
+    protected $target;
+
+    protected $attributes = [];
+
+    protected $filters = [];
+
+    public static function normalizeName($name)
+    {
+        $prefix = null;
+        if (is_array($name)) {
+            $prefix = $name[0];
+            $name = $name[1];
+        }
+
+        $name = str_replace(self::PREFIX_DELIMITER . '/', self::PREFIX_DELIMITER, trim(str_replace('\\', '/', $name), '/'));
+        if (!$prefix) {
+            return $name;
+        }
+        return $prefix . self::PREFIX_DELIMITER . $name;
+    }
+
+    public static function factory($name, $options, $assetsManager = null)
+    {
+        if (is_string($options)) {
+            $options = ['source' => $options];
+        }
+        if (isset($options['assets'])) {
+            return new Alias($name, $options, $assetsManager);
+        }
+
+        return new Asset($name, $options);
+    }
+
+    public function __construct($name, $options)
+    {
+        $this->name = self::normalizeName($name);
+
+        if (isset($options['target'])) {
+            $this->target = self::normalizeName($options['target']);
+        }
+
+        if (isset($options['attributes'])) {
+            $this->attributes = $options['attributes'];
+        }
+        if (isset($options['filters'])) {
+            $this->filters = $options['filters'];
+        }
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getTarget()
+    {
+        return $this->target;
+    }
+
+    public function getAttributes($key = null)
+    {
+        if ($key == null) {
+            return $this->attributes;
+        }
+        return isset($this->attributes[$key])
+            ? $this->attributes[$key]
+            : null;
+    }
+
+    public function getFilters()
+    {
+        return $this->filters;
+    }
+
+    public function hasFilters()
+    {
+        return !empty($this->filters);
+    }
+}

--- a/src/Assets/Alias.php
+++ b/src/Assets/Alias.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets;
+
+class Alias extends AbstractAsset implements \Iterator, \Countable
+{
+    /**
+     * @var AssetsManager
+     */
+    protected $assetsManager;
+
+    protected $assets = [];
+
+    public function __construct($name, $options, AssetsManager $assetsManager)
+    {
+        parent::__construct($name, $options);
+
+        $this->assetsManager = $assetsManager;
+
+        if (isset($options['assets'])) {
+            if (is_string($options['assets'])) {
+                $options['assets'] = [$options['assets']];
+            }
+            foreach ($options['assets'] as $sourceName => $sourceOptions) {
+                if (is_numeric($sourceName)) {
+                    $this->set($sourceOptions, []);
+                } else {
+                    $this->set($sourceName, $sourceOptions);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function has($name)
+    {
+        return isset($this->assets[self::normalizeName($name)]);
+    }
+
+    /**
+     * @param string $name
+     * @return Asset|Alias
+     */
+    public function get($name)
+    {
+        $name = self::normalizeName($name);
+        if (!isset($this->assets[$name])) {
+            return;
+        }
+        return $this->resolveAsset($name, $this->assets[$name]);
+    }
+
+    /**
+     * @param string $name
+     * @param array $source
+     * @return self
+     */
+    public function set($name, $source)
+    {
+        $name = self::normalizeName($name);
+        $this->assets[$name] = $source;
+        return $this;
+    }
+
+    /**
+     * @param type $name
+     * @param type $source
+     * @return Asset
+     */
+    protected function resolveAsset($name, $source)
+    {
+        if ($source instanceof AbstractAsset) {
+            return $source;
+        }
+        if ($this->assetsManager->has($name)) {
+            $source = $this->assetsManager->get($name);
+        } else {
+            $source = new Asset($name, $source);
+        }
+        $this->assets[$name] = $source;
+        return $source;
+    }
+
+    public function current()
+    {
+        return $this->resolveAsset(
+            key($this->assets),
+            current($this->assets)
+        );
+    }
+
+    public function key()
+    {
+        return key($this->assets);
+    }
+
+    public function next()
+    {
+        $next = next($this->assets);
+        if (!$next) {
+            return false;
+        }
+        return $this->resolveAsset(
+            key($this->assets),
+            $next
+        );
+    }
+
+    public function rewind()
+    {
+        reset($this->assets);
+    }
+
+    public function valid()
+    {
+        return current($this->assets) !== false;
+    }
+
+    public function count()
+    {
+        return count($this->assets);
+    }
+}

--- a/src/Assets/Asset.php
+++ b/src/Assets/Asset.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets;
+
+class Asset extends AbstractAsset
+{
+    protected $prefix;
+    protected $source;
+    protected $isExternal;
+
+    public function __construct($name, $options = [])
+    {
+        if (is_string($options)) {
+            $options = ['source' => $options];
+        }
+        parent::__construct($name, $options);
+
+        if (false !== ($posName = stripos($this->name, self::PREFIX_DELIMITER))) {
+            $this->prefix = substr($this->name, 0, $posName);
+        }
+
+        $this->source = isset($options['source'])
+                ? self::normalizeName($options['source'])
+                : $this->name;
+
+        $this->target = $this->target ?: $this->name;
+        if (false !== ($posTarget = stripos($this->target, self::PREFIX_DELIMITER))) {
+            $this->target = substr($this->target, $posTarget + strlen(self::PREFIX_DELIMITER));
+        }
+
+        $this->isExternal = (stripos($this->target, 'http') === 0);
+    }
+
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    public function getSource()
+    {
+        return $this->source;
+    }
+
+    public function isExternal()
+    {
+        return $this->isExternal;
+    }
+}

--- a/src/Assets/AssetsManager.php
+++ b/src/Assets/AssetsManager.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets;
+
+use Zend\Stdlib\ArrayUtils;
+use Zend\View\Exception;
+use Zend\View\Resolver\ResolverInterface;
+
+class AssetsManager
+{
+    protected $currentGroup = 'default';
+
+    protected $assets = [];
+
+    protected $filters = [];
+
+    protected $publicFolder = '/public';
+
+    /**
+     * @var ResolverInterface
+     */
+    protected $mimeResolver;
+
+    public function __construct(array $options = [])
+    {
+        if (isset($options['assets'])) {
+            foreach ($options['assets'] as $group => $aliases) {
+                foreach ($aliases as $alias => $aliasOptions) {
+                    $this->set($alias, $aliasOptions, $group);
+                }
+            }
+        }
+        if (isset($options['filters'])) {
+            foreach ($options['filters'] as $rule => $filters) {
+                $this->setFilter($rule, $filters);
+            }
+        }
+        if (isset($options['public_folder'])) {
+            $this->setPublicFolder($options['public_folder']);
+        }
+    }
+
+    /**
+     * @param string $alias
+     * @param string|array $assets
+     * @return self
+     * @throws \Exception\InvalidArgumentException
+     */
+    public function set($name, $asset, $group = null)
+    {
+        if (is_string($name) && !(is_string($asset) || is_array($asset) || $asset instanceof AbstractAsset)) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: expects "$asset" parameter an %s, %s, %s or %s, received "%s"',
+                __METHOD__,
+                Asset::class,
+                Assets::class,
+                'string',
+                'array',
+                (is_object($asset) ? get_class($asset) : gettype($asset))
+            ));
+        }
+        $group = $group ?: $this->currentGroup;
+        if ($name instanceof AbstractAsset) {
+            $name = $name->getName();
+            $asset = $name;
+        } else {
+            $name = Asset::normalizeName($name);
+        }
+        $this->assets[$group][$name] = $asset;
+        return $this;
+    }
+
+    /**
+     * @param string $name
+     * @return Asset
+     */
+    public function get($name)
+    {
+        $name = Asset::normalizeName($name);
+        if (!isset($this->assets[$this->currentGroup][$name])) {
+            return;
+        }
+        $asset = $this->assets[$this->currentGroup][$name];
+        if (!$asset instanceof AbstractAsset) {
+            $asset = AbstractAsset::factory($name, $asset, $this);
+            $this->assets[$this->currentGroup][$name] = $asset;
+        }
+        return $asset;
+    }
+
+    /**
+     * @param string $name
+     * @return bool
+     */
+    public function has($name)
+    {
+        $name = Asset::normalizeName($name);
+        return isset($this->assets[$this->currentGroup][$name]);
+    }
+
+    public function setFilter($rule, $filters)
+    {
+        $this->filters[$rule] = (array)$filters;
+        return $this;
+    }
+
+    public function hasAssetFilters(Asset $asset)
+    {
+        if ($asset->hasFilters()) {
+            return true;
+        }
+
+        $source = $asset->getName();
+        foreach ($this->filters as $rule => $filters) {
+            if (preg_match('(^' . $rule . '$)', $source)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function getAssetFilters(Asset $asset)
+    {
+        $source = $asset->getName();
+        $result = $asset->getFilters();
+        foreach ($this->filters as $rule => $filters) {
+            if (!preg_match('(^' . $rule . '$)', $source)) {
+                continue;
+            }
+            $result = ArrayUtils::merge($filters, $result);
+        }
+        return $result;
+    }
+
+    /**
+     * @param string $currentGroup
+     * @return self
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setCurrentGroup($currentGroup)
+    {
+        if (!$currentGroup) {
+            throw new Exception\InvalidArgumentException('Current group should be not empty string');
+        }
+        $this->currentGroup = strtolower($currentGroup);
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getCurrentGroup()
+    {
+        return $this->currentGroup;
+    }
+
+    /**
+     * @param string $publicFolder
+     * @return self
+     * @throws Exception\InvalidArgumentException
+     */
+    public function setPublicFolder($publicFolder)
+    {
+        $publicFolder = trim(trim($publicFolder, '.'), '/');
+        if (!$publicFolder) {
+            throw new Exception\InvalidArgumentException('Public folder should be not empty string');
+        }
+        $this->publicFolder = './' . $publicFolder;
+        return $this;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPublicFolder()
+    {
+        return $this->publicFolder;
+    }
+
+    /**
+     * @param ResolverInterface $mimeResolver
+     * @return self
+     */
+    public function setMimeResolver(ResolverInterface $mimeResolver)
+    {
+        $this->mimeResolver = $mimeResolver;
+        return $this;
+    }
+
+    /**
+     * @return ResolverInterface
+     */
+    public function getMimeResolver()
+    {
+        return $this->mimeResolver;
+    }
+}

--- a/src/Assets/MimeResolver.php
+++ b/src/Assets/MimeResolver.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets;
+
+use Zend\View\Resolver\ResolverInterface;
+use Zend\View\Renderer\RendererInterface;
+use Zend\Stdlib\ArrayUtils;
+
+class MimeResolver implements ResolverInterface
+{
+    protected $defaultMimeType = 'text/plain';
+
+    protected $mimeTypes = [
+        'css'      => 'text/css',
+        'less'     => 'text/css',
+        'sass'     => 'text/css',
+        'scss'     => 'text/css',
+        'gif'      => 'image/gif',
+        'htm'      => 'text/html',
+        'html'     => 'text/html',
+        'ico'      => 'image/x-icon',
+        'jpe'      => 'image/jpeg',
+        'jpeg'     => 'image/jpeg',
+        'jpg'      => 'image/jpeg',
+        'js'       => 'application/javascript',
+        'json'     => 'application/json',
+        'pdf'      => 'application/pdf',
+        'png'      => 'image/png',
+        'tif'      => 'image/tiff',
+        'tiff'     => 'image/tiff',
+        'txt'      => 'text/plain',
+        'xml'      => 'application/xml',
+        'xsd'      => 'application/xml',
+        'xsl'      => 'application/xml',
+    ];
+
+    public function __construct($mimeTypes = [])
+    {
+        if ($mimeTypes) {
+            $this->mimeTypes = ArrayUtils::merge($this->mimeTypes, $mimeTypes);
+        }
+    }
+
+    public function resolve($name, RendererInterface $renderer = null)
+    {
+        $ext = explode('.', $name);
+        $ext = end($ext);
+        if (isset($this->mimeTypes[$ext])) {
+            return $this->mimeTypes[$ext];
+        }
+        return $this->defaultMimeType;
+    }
+
+    public function setMimeType($extension, $type)
+    {
+        $this->mimeTypes[$extension] = $type;
+        return $this;
+    }
+}

--- a/src/Assets/Service/AssetsManagerFactory.php
+++ b/src/Assets/Service/AssetsManagerFactory.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets\Service;
+
+use Zend\ServiceManager\FactoryInterface;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\View\Assets\AssetsManager;
+
+class AssetsManagerFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $config = $container->get('config');
+        $managerConfig = isset($config['assets_manager']) ? $config['assets_manager'] : [];
+        $instance = new AssetsManager($managerConfig);
+        if ($container->has('MimeResolver')) {
+            $mimeResolver = $container->get('MimeResolver');
+        } else {
+            $factory = new MimeResolverFactory;
+            $mimeResolver = $factory($container, 'MimeResolver');
+        }
+        $instance->setMimeResolver($mimeResolver);
+        return $instance;
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator, $rName = null, $cName = null)
+    {
+        return $this($serviceLocator, $cName);
+    }
+}

--- a/src/Assets/Service/AssetsResolverFactory.php
+++ b/src/Assets/Service/AssetsResolverFactory.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets\Service;
+
+use Zend\ServiceManager\FactoryInterface;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\View\Resolver as ViewResolver;
+use Zend\Stdlib\ArrayUtils;
+use Zend\View\Exception\DomainException;
+
+class AssetsResolverFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $config = $container->get('config');
+
+        if (!isset($config['assets_manager'])) {
+            throw new DomainException(sprintf(
+                '%s: expects "assets_manager" key in Config',
+                __METHOD__
+            ));
+        }
+
+        $publicFolder = $container->get('AssetsManager')->getPublicFolder();
+
+        $resolverConfig = isset($config['assets_manager']['template_resolver'])
+                ? $config['assets_manager']['template_resolver']
+                : [];
+
+        if (isset($resolverConfig['path_resolver']['script_paths'])) {
+            $resolverConfig['path_resolver']['script_paths'] = ArrayUtils::merge(
+                [$publicFolder],
+                $resolverConfig['path_resolver']['script_paths']
+            );
+        } else {
+            $resolverConfig['path_resolver']['script_paths'] = [
+                $publicFolder,
+            ];
+        }
+
+        $resolver = new ViewResolver\AggregateResolver();
+        foreach ($resolverConfig as $name => $options) {
+            if (!$options) {
+                continue;
+            }
+            switch ($name) {
+                case 'prefix_resolver' :
+                    $resolver->attach(new ViewResolver\PrefixPathStackResolver($options));
+                    break;
+                case 'map_resolver' :
+                    $resolver->attach(new ViewResolver\TemplateMapResolver($options));
+                    break;
+                case 'path_resolver' :
+                    $resolver->attach(new ViewResolver\TemplatePathStack($options));
+                    break;
+            }
+        }
+        return $resolver;
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator, $rName = null, $cName = null)
+    {
+        return $this($serviceLocator, $cName);
+    }
+}

--- a/src/Assets/Service/MimeResolverFactory.php
+++ b/src/Assets/Service/MimeResolverFactory.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Assets\Service;
+
+use Zend\ServiceManager\FactoryInterface;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\View\Assets\MimeResolver;
+
+class MimeResolverFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $config = $container->get('config');
+        return new MimeResolver(
+            isset($config['assets_manager']['mime_types'])
+                ? $config['assets_manager']['mime_types']
+                : []
+        );
+    }
+
+    public function createService(ServiceLocatorInterface $serviceLocator, $rName = null, $cName = null)
+    {
+        return $this($serviceLocator, $cName);
+    }
+}

--- a/src/Helper/Assets.php
+++ b/src/Helper/Assets.php
@@ -1,0 +1,304 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2014 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Helper;
+
+use Zend\View\Assets\AssetsManager;
+use Zend\Stdlib\ArrayUtils;
+use Zend\Stdlib\PriorityList;
+use Zend\View\Exception;
+use Zend\View\Assets as AssetsEngine;
+
+/**
+ * @method self add($asset, $options = [])
+ * @method string render()
+ */
+class Assets extends AbstractHelper
+{
+    protected $basePath = '';
+
+    protected $defaultGroup = 'default';
+
+    protected $groups = [];
+
+    protected $routeName;
+
+    protected $urlHelper;
+
+    protected $rendered = [];
+
+    protected $EOL = "\n";
+
+    protected $mimeRenderers = [
+        'default'                => 'HeadLink',
+        'application/javascript' => 'HeadScript',
+    ];
+
+    protected $mimeAttributes = [
+        'text/css' => [
+            'rel'   => 'stylesheet',
+        ]
+    ];
+
+    /**
+     * @var AssetsManager
+     */
+    protected $assetsManager;
+
+    /**
+     * @param type $method
+     * @param type $arguments
+     * @return self
+     * @throws Exception\BadMethodCallException
+     */
+    public function __call($method, $arguments)
+    {
+        if (stripos($method, 'add') === 0) {
+            $group = substr($method, 3) ?: $this->defaultGroup;
+            $asset = $arguments[0];
+            $options = isset($arguments[1]) ? $arguments[1] : [];
+            $priority = isset($arguments[2]) ? $arguments[2] : 1;
+            return $this->addAsset($group, $asset, $options, $priority);
+        }
+
+        if (stripos($method, 'render') === 0) {
+            return $this->renderGroup(substr($method, 6) ?: $this->defaultGroup);
+        }
+
+        throw new Exception\BadMethodCallException('Method "' . $method . '" does not exist');
+    }
+
+    /**
+     * @param string $group
+     * @param string|array|Asset $asset
+     * @param array $options
+     * @param int $priority
+     * @return self
+     */
+    protected function addAsset($group, $asset, $options = [], $priority = 1)
+    {
+        $group = strtolower($group);
+        if (!isset($this->groups[$group])) {
+            $list = new PriorityList();
+            $list->isLIFO(false);
+            $this->groups[$group] = $list;
+        } else {
+            $list = $this->groups[$group];
+        }
+        if (is_numeric($options)) {
+            $priority = $options;
+            $options = [];
+        }
+        $asset = AssetsEngine\AbstractAsset::normalizeName($asset);
+        if ($list->get($asset) === null) {
+            $list->insert($asset, $options, $priority);
+        }
+        return $this;
+    }
+
+    protected function renderGroup($group)
+    {
+        $group = strtolower($group);
+        if (isset($this->rendered[$group])) {
+            return '';
+        }
+
+        if (!isset($this->groups[$group])) {
+            return '';
+        }
+
+        $result = '';
+        foreach ($this->groups[$group] as $asset => $attributes) {
+            if (!$this->assetsManager->has($asset)) {
+                $asset = new AssetsEngine\Asset($asset);
+            } else {
+                $asset = $this->assetsManager->get($asset);
+            }
+            $result .= $this->renderAsset($asset, $attributes);
+        }
+        $this->rendered[$group] = true;
+        return trim($result, $this->EOL) . $this->EOL;
+    }
+
+    protected function renderAsset(AssetsEngine\AbstractAsset $asset, $attributes = [])
+    {
+        if ($asset instanceof AssetsEngine\Asset) {
+            return $this->renderLink(null, $asset, $attributes) . $this->EOL;
+        }
+        if (!$asset instanceof AssetsEngine\Alias) {
+            throw new Exception\InvalidArgumentException(sprintf(
+                '%s: expects "$asset" parameter an %s or %s, received "%s"',
+                __METHOD__,
+                AssetsEngine\Asset::class,
+                AssetsEngine\Alias::class,
+                (is_object($asset) ? get_class($asset) : gettype($asset))
+            ));
+        }
+
+        $return = '';
+        $attributes = ArrayUtils::merge($asset->getAttributes(), $attributes);
+        foreach ($asset as $assetItem) {
+            if ($assetItem instanceof AssetsEngine\Alias) {
+                $return .= $this->renderAsset($assetItem, $attributes) . $this->EOL;
+            } else {
+                $return .= $this->renderLink($asset->getName(), $assetItem, $attributes) . $this->EOL;
+            }
+        }
+        return $return;
+    }
+
+    protected function renderLink($alias, AssetsEngine\Asset $asset, $attributes = [])
+    {
+        $href = $this->assemble($alias, $asset);
+
+        if (isset($this->rendered[$href])) {
+            return '';
+        }
+        $this->rendered[$href] = true;
+
+        $mimeType = $asset->getAttributes('type') ?: $this->assetsManager->getMimeResolver()->resolve($asset->getTarget());
+
+        $attributes = ArrayUtils::merge(
+            ArrayUtils::merge($this->getMimeAttributes($mimeType), $asset->getAttributes()),
+            $attributes
+        );
+
+        $renderer = $this->getMimeRenderer($mimeType);
+
+        if ($mimeType == 'application/javascript') {
+            $attributes['src'] = $href;
+            return $renderer->itemToString((object)[
+                'type'       => $mimeType,
+                'attributes' => $attributes,
+            ], null, null, null);
+        }
+
+        $attributes['href'] = $href;
+        $attributes['type'] = $mimeType;
+
+        if (isset($attributes['conditional'])) {
+            $attributes['conditionalStylesheet'] = $attributes['conditional'];
+            unset($attributes['conditional']);
+        }
+
+        return $renderer->itemToString((object)$attributes, '');
+    }
+
+    protected function assemble($alias, AssetsEngine\Asset $asset)
+    {
+        if ($asset->isExternal()) {
+            return $asset->getTarget();
+        }
+        if (!$alias && !$asset->getPrefix()) {
+            return $this->basePath . '/' . $asset->getTarget();
+        }
+
+        if (!$this->routeName) {
+            throw new Exception\InvalidArgumentException('Using modules assets require the valid "routeName"');
+        }
+
+        if (!$this->urlHelper) {
+            $this->urlHelper = $this->getView()->plugin('url');
+        }
+
+        $href = $this->urlHelper->__invoke($this->routeName, [
+            'alias'  => $alias,
+            'prefix' => $asset->getPrefix(),
+            'asset'  => $asset->getTarget(),
+        ], [
+            'reuse_query'      => false,
+            'only_return_path' => true,
+        ]);
+        return '/' . ltrim($href, '/');
+    }
+
+    public function getMimeRenderer($contentType)
+    {
+        if (!isset($this->mimeRenderers[$contentType])) {
+            $contentType = 'default';
+        }
+        if (is_string($this->mimeRenderers[$contentType])) {
+            $this->mimeRenderers[$contentType] = $this->getView()->plugin($this->mimeRenderers[$contentType]);
+        }
+        return $this->mimeRenderers[$contentType];
+    }
+
+    public function setMimeRenderer($contentType, $renderer)
+    {
+        $this->mimeRenderers[$contentType] = $renderer;
+        return $this;
+    }
+
+    public function setRouteName($routeName)
+    {
+        $this->routeName = $routeName;
+        return $this;
+    }
+
+    public function getRouteName()
+    {
+        return $this->routeName;
+    }
+
+    public function setBasePath($basePath)
+    {
+        $this->basePath = $basePath;
+        return $this;
+    }
+
+    public function getBasePath()
+    {
+        return $this->basePath;
+    }
+
+    public function getMimeAttributes($mime = null)
+    {
+        if (!$mime) {
+            return $this->mimeAttributes;
+        }
+        return isset($this->mimeAttributes[$mime])
+                ? $this->mimeAttributes[$mime]
+                : [];
+    }
+
+    public function setMimeAttributes($mime, $attributes = [])
+    {
+        if (is_array($mime)) {
+            foreach ($mime as $type => $attributes) {
+                $this->mimeAttributes[$type] = $attributes;
+            }
+            return $this;
+        }
+        $this->mimeAttributes[$mime] = $attributes;
+        return $this;
+    }
+
+    /**
+     * @param AssetsManager $assetsManager
+     * @return self
+     */
+    public function setAssetsManager(AssetsManager $assetsManager)
+    {
+        $this->assetsManager = $assetsManager;
+        return $this;
+    }
+
+    /**
+     * @return AssetsManager
+     */
+    public function getAssetsManager()
+    {
+        return $this->assetsManager;
+    }
+
+    public function __toString()
+    {
+        return $this->renderGroup($this->defaultGroup);
+    }
+}

--- a/src/Helper/Service/AssetsFactory.php
+++ b/src/Helper/Service/AssetsFactory.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace Zend\View\Helper\Service;
+
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\FactoryInterface;
+use Zend\ServiceManager\ServiceLocatorInterface;
+use Zend\View\Assets\Service\AssetsManagerFactory;
+use Zend\View\Helper\Assets;
+
+class AssetsFactory implements FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $name, array $options = null)
+    {
+        $config = $container->get('config');
+        $config = isset($config['assets_manager']) ? $config['assets_manager'] : [];
+
+        $instance = new Assets();
+        if ($container->has('AssetsManager')) {
+            $assetsManager = $container->get('AssetsManager');
+        } else {
+            $factory = new AssetsManagerFactory;
+            $assetsManager = $factory($container, 'AssetsManager');
+        }
+        $instance->setAssetsManager($assetsManager);
+        $instance->setRouteName(isset($config['router_name']) ? $config['router_name'] : null);
+        $instance->setMimeAttributes(isset($config['mime_attributes']) ? $config['mime_attributes'] : []);
+
+        if ($container->has('Request')) {
+            $request = $container->get('Request');
+            if (is_callable([$request, 'getBasePath'])) {
+                $instance->setBasePath($request->getBasePath());
+            }
+        }
+        return $instance;
+    }
+
+    /**
+     * Create service
+     *
+     * @param ServiceLocatorInterface $serviceLocator
+     * @return mixed
+     */
+    public function createService(ServiceLocatorInterface $serviceLocator, $rName = null, $cName = null)
+    {
+        return $this($serviceLocator, $cName);
+    }
+}

--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -37,6 +37,8 @@ class HelperPluginManager extends AbstractPluginManager
      * @var string[]
      */
     protected $aliases = [
+        'Assets'              => Helper\Assets::class,
+        'assets'              => Helper\Assets::class,
         'basePath'            => Helper\BasePath::class,
         'BasePath'            => Helper\BasePath::class,
         'basepath'            => Helper\BasePath::class,
@@ -150,6 +152,7 @@ class HelperPluginManager extends AbstractPluginManager
     protected $factories = [
         Helper\FlashMessenger::class      => Helper\Service\FlashMessengerFactory::class,
         Helper\Identity::class            => Helper\Service\IdentityFactory::class,
+        Helper\Assets::class              => Helper\Service\AssetsFactory::class,
         Helper\BasePath::class            => InvokableFactory::class,
         Helper\Cycle::class               => InvokableFactory::class,
         Helper\DeclareVars::class         => InvokableFactory::class,
@@ -188,6 +191,7 @@ class HelperPluginManager extends AbstractPluginManager
 
         'zendviewhelperflashmessenger'    => Helper\Service\FlashMessengerFactory::class,
         'zendviewhelperidentity'          => Helper\Service\IdentityFactory::class,
+        'zendviewhelperassets'            => InvokableFactory::class,
         'zendviewhelperbasepath'          => InvokableFactory::class,
         'zendviewhelpercycle'             => InvokableFactory::class,
         'zendviewhelperdeclarevars'       => InvokableFactory::class,

--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -70,6 +70,7 @@ use Zend\View\Variables;
  * @method \Zend\View\Helper\Navigation\Links links($container = null)
  * @method \Zend\View\Helper\Navigation\Menu menu($container = null)
  * @method \Zend\View\Helper\Navigation\Sitemap sitemap($container = null)
+ * @method \Zend\View\Helper\Assets assets($group, $asset, $options = [], $priority = 1)
  */
 class PhpRenderer implements Renderer, TreeRendererInterface
 {

--- a/test/Assets/AbstractAssetTest.php
+++ b/test/Assets/AbstractAssetTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Assets;
+
+use Zend\View\Assets\Asset;
+use Zend\View\Assets\Alias;
+use Zend\View\Assets\AbstractAsset;
+use Zend\View\Assets\AssetsManager;
+
+/**
+ * @group      Zend_View
+ */
+class AbstractAssetTest extends \PHPUnit_Framework_TestCase
+{
+    public function testNormalizeName()
+    {
+        $this->assertEquals(
+            'foo/bar/baz.css',
+            AbstractAsset::normalizeName('\foo/bar\baz.css')
+        );
+        $this->assertEquals(
+            'http://foo/bar/baz.css',
+            AbstractAsset::normalizeName('http://foo\bar\baz.css')
+        );
+        $this->assertEquals(
+            'prefix::foo/bar/baz.css',
+            AbstractAsset::normalizeName('prefix::/foo\bar\baz.css')
+        );
+        $this->assertEquals(
+            'prefix::foo/bar/baz.css',
+            AbstractAsset::normalizeName(['prefix', '\foo\bar/baz.css'])
+        );
+        $this->assertEquals(
+            'foo/bar/baz.css',
+            AbstractAsset::normalizeName([null, '\foo\bar/baz.css'])
+        );
+    }
+
+    public function testFactory()
+    {
+        $assetsManager = new AssetsManager();
+        $asset = AbstractAsset::factory('foo', 'bar', $assetsManager);
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals('bar', $asset->getSource());
+
+        $asset = AbstractAsset::factory('foo', ['source' => 'bar'], $assetsManager);
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals('bar', $asset->getSource());
+
+        $asset = AbstractAsset::factory('foo', [], $assetsManager);
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals('foo', $asset->getName());
+
+        $alias = AbstractAsset::factory('foo', ['assets' => 'bar'], $assetsManager);
+        $this->assertInstanceOf(Alias::class, $alias);
+        $this->assertEquals('foo', $alias->getName());
+        $this->assertEquals(
+            new Asset('bar'),
+            $alias->get('bar')
+        );
+    }
+}

--- a/test/Assets/AliasTest.php
+++ b/test/Assets/AliasTest.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Assets;
+
+use Zend\View\Assets\AssetsManager;
+use Zend\View\Assets\Alias;
+use Zend\View\Assets\Asset;
+
+/**
+ * @group      Zend_View
+ */
+class AssetsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AssetsManager
+     */
+    protected $assetsManager;
+
+    public function setUp()
+    {
+        $this->assetsManager = new AssetsManager();
+    }
+
+    public function testConstructor()
+    {
+        // empty sources
+        $alias = new Alias('foo', [], $this->assetsManager);
+        $this->assertEquals(0, $alias->count());
+
+        // string sources
+        $alias = new Alias('foo', ['assets' => 'bar.css'], $this->assetsManager);
+        $asset = $alias->get('bar.css');
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals('bar.css', $asset->getName());
+
+        // array sources
+        $alias = new Alias('foo', ['assets' => ['bar.css', 'baz.css']], $this->assetsManager);
+        $asset = $alias->get('bar.css');
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals('bar.css', $asset->getName());
+
+        $asset = $alias->get('baz.css');
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals('baz.css', $asset->getName());
+
+        // array with attributes
+        $alias = new Alias('foo', ['assets' => [
+            'bar.css' => [
+                'attributes' => ['k' => 'v'],
+            ],
+        ]], $this->assetsManager);
+        $asset = $alias->get('bar.css');
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals('bar.css', $asset->getName());
+        $this->assertEquals(['k' => 'v'], $asset->getAttributes());
+    }
+
+    public function testSet()
+    {
+        $alias = new Alias('foo', [], $this->assetsManager);
+        $alias
+            ->set('foo.css', [])
+            ->set('bar.css', [
+                    'attributes' => ['k' => 'v'],
+            ]);
+        $this->assertInstanceOf(Asset::class, $alias->get('foo.css'));
+        $this->assertInstanceOf(Asset::class, $alias->get('bar.css'));
+        $this->assertEquals(['k' => 'v'], $alias->get('bar.css')->getAttributes());
+    }
+
+    public function testHas()
+    {
+        $alias = new Alias('foo', [
+            'assets' => ['/bar\baz.css'],
+        ], $this->assetsManager);
+
+        $this->assertTrue($alias->has('\bar\baz.css'));
+        $this->assertTrue($alias->has('bar/baz.css'));
+        $this->assertTrue($alias->has('/bar\baz.css'));
+        $this->assertFalse($alias->has('notExist'));
+    }
+
+    public function testIterator()
+    {
+        $alias = new Alias('foo', [], $this->assetsManager);
+        $alias
+            ->set('bar.css', 'bar.less')
+            ->set('bat.css', 'bat.less');
+
+        $array = [];
+        foreach ($alias as $k => $v) {
+            $array[$k] = $v;
+        }
+        $this->assertEquals([
+            'bar.css' => new Asset('bar.css', 'bar.less'),
+            'bat.css' => new Asset('bat.css', 'bat.less'),
+        ], $array);
+    }
+}

--- a/test/Assets/AssetTest.php
+++ b/test/Assets/AssetTest.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Assets;
+
+use Zend\View\Assets\Asset;
+use Zend\View\Assets\AssetsManager;
+
+/**
+ * @group      Zend_View
+ */
+class AssetTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AssetsManager
+     */
+    protected $assetsManager;
+
+    public function setUp()
+    {
+        $this->assetsManager = new AssetsManager();
+    }
+
+    public function testConstructor()
+    {
+        $asset = new Asset('foo.css', [
+            'attributes' => ['foo' => 'bar'],
+            'filters'    => ['baz'],
+        ]);
+        $this->assertEquals('foo.css', $asset->getName());
+        $this->assertFalse($asset->isExternal());
+        $this->assertNull($asset->getPrefix());
+        $this->assertEquals(['foo' => 'bar'], $asset->getAttributes());
+        $this->assertEquals(['baz'], $asset->getFilters());
+
+        $asset = new Asset('http://foo.css');
+        $this->assertEquals('http://foo.css', $asset->getName());
+        $this->assertTrue($asset->isExternal());
+        $this->assertNull($asset->getPrefix());
+
+        $asset = new Asset('module::/foo.css');
+        $this->assertEquals('module::foo.css', $asset->getName());
+        $this->assertFalse($asset->isExternal());
+        $this->assertEquals('module', $asset->getPrefix());
+        $this->assertEquals('module::foo.css', $asset->getSource());
+    }
+
+    public function testSourceAndTarget()
+    {
+        $asset = new Asset('foo.css', [
+            'source'    => 'foo.less',
+        ]);
+        $this->assertEquals('foo.css', $asset->getName());
+        $this->assertEquals('', $asset->getPrefix());
+        $this->assertEquals('foo.less', $asset->getSource());
+        $this->assertEquals('foo.css', $asset->getTarget());
+
+        $asset = new Asset('pre::foo.css', [
+            'source'    => 'pre::foo.less',
+        ]);
+        $this->assertEquals('pre::foo.css', $asset->getName());
+        $this->assertEquals('pre', $asset->getPrefix());
+        $this->assertEquals('pre::foo.less', $asset->getSource());
+        $this->assertEquals('foo.css', $asset->getTarget());
+
+        $asset = new Asset('foo.css', [
+            'source'    => 'pre::foo.less',
+        ]);
+        $this->assertEquals('foo.css', $asset->getName());
+        $this->assertEquals('', $asset->getPrefix());
+        $this->assertEquals('pre::foo.less', $asset->getSource());
+        $this->assertEquals('foo.css', $asset->getTarget());
+
+        $asset = new Asset('foo.css', 'pre::foo.less');
+        $this->assertEquals('foo.css', $asset->getName());
+        $this->assertEquals('', $asset->getPrefix());
+        $this->assertEquals('pre::foo.less', $asset->getSource());
+        $this->assertEquals('foo.css', $asset->getTarget());
+    }
+}

--- a/test/Assets/AssetsManagerTest.php
+++ b/test/Assets/AssetsManagerTest.php
@@ -1,0 +1,236 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Assets;
+
+use Zend\View\Assets\AssetsManager;
+use Zend\View\Assets\Asset;
+use Zend\View\Assets\Alias;
+use Zend\View\Exception;
+
+/**
+ * @group      Zend_View
+ */
+class AssetsManagerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AssetsManager
+     */
+    protected $assetsManager;
+
+    public function setUp()
+    {
+        $this->assetsManager = new AssetsManager();
+    }
+
+    public function testSetGetHas()
+    {
+        $this->assetsManager
+                ->set('/string-asset.css', '/string.less')
+                ->set('/string-asset.css', '/string.less')
+                ->set('/array-asset.css', [
+                    'source' => '/foo.less',
+                    'attributes' => [],
+                ])
+                ->set('/array-asset-no-source.css', [
+                    'attributes' => [],
+                ])
+                ->set('pre::/prefix-string-assets.css', [
+                    'assets' => '/css/bar.less',
+                    'attributes' => [],
+                ])
+                ->set('array-assets', [
+                    'assets' => [
+                        '/string-asset.css',
+                        'pre::/prefix-string-assets.css',
+                        'array-asset.css' => [
+                            'source' => 'baz.less',
+                            'attributes' => [],
+                        ],
+                        '/string-source.css',
+                    ],
+                    'attributes' => [],
+                ]);
+
+        $stringAssetCss = $this->assetsManager->get('string-asset.css');
+        $this->assertTrue($this->assetsManager->has('string-asset.css'));
+        $this->assertInstanceOf(Asset::class, $stringAssetCss);
+
+        $arrayAssetCss = $this->assetsManager->get('array-asset.css');
+        $this->assertTrue($this->assetsManager->has('array-asset.css'));
+        $this->assertInstanceOf(Asset::class, $arrayAssetCss);
+        $this->assertEquals('foo.less', $arrayAssetCss->getSource());
+
+        $arrayAssetNoSourceCss = $this->assetsManager->get('array-asset-no-source.css');
+        $this->assertTrue($this->assetsManager->has('array-asset-no-source.css'));
+        $this->assertInstanceOf(Asset::class, $arrayAssetNoSourceCss);
+
+        $prefixStringAssetsCss = $this->assetsManager->get('pre::/prefix-string-assets.css');
+        $this->assertTrue($this->assetsManager->has('pre::/prefix-string-assets.css'));
+        $this->assertInstanceOf(Alias::class, $prefixStringAssetsCss);
+
+        $arrayAssets = $this->assetsManager->get('array-assets');
+        $this->assertTrue($this->assetsManager->has('array-assets'));
+        $this->assertInstanceOf(Alias::class, $arrayAssets);
+
+        $source1 = $arrayAssets->get('string-asset.css');
+        $this->assertTrue($arrayAssets->has('string-asset.css'));
+        $this->assertSame($stringAssetCss, $source1);
+
+        $source2 = $arrayAssets->get('pre::/prefix-string-assets.css');
+        $this->assertTrue($arrayAssets->has('pre::/prefix-string-assets.css'));
+        $this->assertSame($prefixStringAssetsCss, $source2);
+
+        $source3 = $arrayAssets->get('array-asset.css');
+        $this->assertTrue($arrayAssets->has('array-asset.css'));
+        $this->assertInstanceOf(Asset::class, $source3);
+
+        $source4 = $arrayAssets->get('string-source.css');
+        $this->assertTrue($arrayAssets->has('string-source.css'));
+        $this->assertInstanceOf(Asset::class, $source4);
+
+        $this->assertFalse($arrayAssets->has('notExist'));
+        $this->assertFalse($this->assetsManager->has('notExist'));
+    }
+
+    public function testSetInvalidAlias()
+    {
+        $this->setExpectedException(
+            Exception\InvalidArgumentException::class,
+            'Zend\View\Assets\AssetsManager::set: expects "$asset" parameter an Zend\View\Assets\Asset, Zend\View\Assets\Assets, string or array, received "stdClass"'
+        );
+        $this->assetsManager->set('a1', new \stdClass());
+    }
+
+    public function testCurrentGroup()
+    {
+        $this->assertEquals('default', $this->assetsManager->getCurrentGroup());
+
+        $this->assetsManager->setCurrentGroup('group-1')
+                ->set('foo.css', []);
+        $this->assetsManager->setCurrentGroup('group-2')
+                ->set('bar.css', []);
+
+        $this->assetsManager->setCurrentGroup('group-1');
+        $this->assertEquals('group-1', $this->assetsManager->getCurrentGroup());
+        $this->assertTrue($this->assetsManager->has('foo.css'));
+        $this->assertFalse($this->assetsManager->has('bar.css'));
+
+        $this->assetsManager->setCurrentGroup('group-2');
+        $this->assertEquals('group-2', $this->assetsManager->getCurrentGroup());
+        $this->assertFalse($this->assetsManager->has('foo.css'));
+        $this->assertTrue($this->assetsManager->has('bar.css'));
+    }
+
+    public function testSetInvalidCurrentGroup()
+    {
+        $this->setExpectedException(Exception\InvalidArgumentException::class, 'Current group should be not empty string');
+        $this->assetsManager->setCurrentGroup('');
+    }
+
+    public function testFilter()
+    {
+        $this->assetsManager
+                ->set('bothFilter.less', [
+                    'filters' => ['filter3'],
+                ])
+                ->set('systemFilter.less', 'filters.less')
+                ->set('assetFilter.css', [
+                    'filters' => ['filter4'],
+                ])
+                ->set('noFilter.css', 'filters.css');
+        $this->assetsManager->setFilter('\S*.less', 'less_filter');
+
+        $asset = $this->assetsManager->get('bothFilter.less');
+        $this->assertEquals(
+            ['less_filter', 'filter3'],
+            $this->assetsManager->getAssetFilters($asset)
+        );
+        $this->assertTrue($this->assetsManager->hasAssetFilters($asset));
+
+        $asset = $this->assetsManager->get('systemFilter.less');
+        $this->assertEquals(
+            ['less_filter'],
+            $this->assetsManager->getAssetFilters($asset)
+        );
+        $this->assertTrue($this->assetsManager->hasAssetFilters($asset));
+
+        $asset = $this->assetsManager->get('assetFilter.css');
+        $this->assertEquals(
+            ['filter4'],
+            $this->assetsManager->getAssetFilters($asset)
+        );
+        $this->assertTrue($this->assetsManager->hasAssetFilters($asset));
+    }
+
+    public function testPublicFolder()
+    {
+        $this->assetsManager->setPublicFolder('foo');
+        $this->assertEquals('./foo', $this->assetsManager->getPublicFolder());
+    }
+
+    public function testSetInvalidPublicFolder()
+    {
+        $this->setExpectedException(Exception\InvalidArgumentException::class, 'Public folder should be not empty string');
+        $this->assetsManager->setPublicFolder('');
+    }
+
+    public function testPassOptionsViaConstructor()
+    {
+        $this->assetsManager = new AssetsManager([
+            'assets' => [
+                'group' => [
+                    'bat.css' => [],
+                ],
+            ],
+            'filters' => ['\S*.css' => 'f1'],
+            'public_folder' => 'bar',
+        ]);
+
+        $this->assetsManager->setCurrentGroup('group');
+        $asset = $this->assetsManager->get('bat.css');
+
+        $this->assertInstanceOf(Asset::class, $asset);
+        $this->assertEquals(['f1'], $this->assetsManager->getAssetFilters($asset));
+        $this->assertEquals('./bar', $this->assetsManager->getPublicFolder());
+    }
+
+    public function testPassAssetsViaConstructor()
+    {
+        $this->assetsManager = new AssetsManager([
+            'assets' => [
+                'default' => [
+                    'foo.css' => [],
+                    'several_assets' => [
+                        'assets' => [
+                            'bar.css',
+                            'bat.js' => [
+                                'attributes' => [
+                                    'charset' => 'UTF-8',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $foo = $this->assetsManager->get('foo.css');
+        $this->assertInstanceOf(Asset::class, $foo);
+
+        $severalAssets = $this->assetsManager->get('several_assets');
+        $this->assertInstanceOf(Alias::class, $severalAssets);
+
+        $asset = $severalAssets->get('bar.css');
+        $this->assertInstanceOf(Asset::class, $asset);
+
+        $asset = $severalAssets->get('bat.js');
+        $this->assertInstanceOf(Asset::class, $asset);
+    }
+}

--- a/test/Assets/Service/AssetsResolverFactoryTest.php
+++ b/test/Assets/Service/AssetsResolverFactoryTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Assets\Service;
+
+use Zend\View\Assets\Service\AssetsResolverFactory;
+use Zend\ServiceManager\ServiceManager;
+use Zend\ServiceManager\Config;
+use Zend\View\Assets\AssetsManager;
+use Zend\View\Exception\DomainException;
+use Zend\View\Resolver\AggregateResolver;
+
+/**
+ * @group      Zend_View
+ */
+class AssetsResolverFactoryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @param array $config
+     * @return ServiceManager
+     */
+    protected function getServiceManager($config)
+    {
+        $config = new Config($config);
+        $serviceManager = new ServiceManager();
+        $config->configureServiceManager($serviceManager);
+        return $serviceManager;
+    }
+
+    public function testFactory()
+    {
+        $factory = new AssetsResolverFactory();
+        $resolver = $factory($this->getServiceManager(['services' => [
+            'config' => ['assets_manager' => [
+                'template_resolver' => [
+                    'path_resolver' => [
+                        'script_paths' => [
+                            'scriptPath'
+                        ]
+                    ],
+                    'map_resolver' => [
+                        'map' => 'map_value'
+                    ],
+                    'prefix_resolver' => [
+                        'prefix' => 'prefix_path',
+                    ],
+                ],
+            ]],
+            'AssetsManager' => new AssetsManager(['public_folder' => 'foo']),
+        ]]), '');
+
+        $this->assertInstanceOf(AggregateResolver::class, $resolver);
+
+        list($path, $map, $prefix) = $resolver->getIterator()->toArray();
+
+        $this->assertEquals(['prefix' => 'prefix_path'], $this->readAttribute($prefix, 'prefixes'));
+        $this->assertEquals(['scriptPath' . DIRECTORY_SEPARATOR, './foo' . DIRECTORY_SEPARATOR], $path->getPaths()->toArray());
+        $this->assertEquals(['map' => 'map_value'], $map->getMap());
+    }
+
+    public function testFactoryWithEmptyConfig()
+    {
+        $factory = new AssetsResolverFactory();
+        $resolver = $factory($this->getServiceManager(['services' => [
+            'config' => ['assets_manager'=>[]],
+            'AssetsManager' => new AssetsManager(['public_folder' => 'foo']),
+        ]]), '');
+
+        $this->assertInstanceOf('Zend\View\Resolver\AggregateResolver', $resolver);
+
+        list($path) = $resolver->getIterator()->toArray();
+
+        $this->assertEquals(['./foo' . DIRECTORY_SEPARATOR], $path->getPaths()->toArray());
+    }
+
+    public function testFactoryWithInvalidConfig()
+    {
+        $factory = new AssetsResolverFactory();
+        $this->setExpectedException(DomainException::class, 'Zend\View\Assets\Service\AssetsResolverFactory::__invoke: expects "assets_manager" key in Config');
+        $factory($this->getServiceManager(['services' => ['config' => []]]), '');
+    }
+}

--- a/test/Helper/AssetsTest.php
+++ b/test/Helper/AssetsTest.php
@@ -1,0 +1,370 @@
+<?php
+/**
+ * Zend Framework (http://framework.zend.com/)
+ *
+ * @link      http://github.com/zendframework/zf2 for the canonical source repository
+ * @copyright Copyright (c) 2005-2015 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   http://framework.zend.com/license/new-bsd New BSD License
+ */
+
+namespace ZendTest\View\Helper;
+
+use Zend\View\Helper;
+use Zend\View\Assets\AssetsManager;
+use Zend\View\Assets\MimeResolver;
+use Zend\View\Exception;
+use Zend\View\Renderer\PhpRenderer as Renderer;
+use Zend\View\HelperPluginManager;
+use Zend\ServiceManager\ServiceManager;
+use Zend\Router\RouteStackInterface;
+
+/**
+ * Test class for Zend\View\Helper\Assets.
+ *
+ * @group      Zend_View
+ * @group      Zend_View_Helper
+ */
+class AssetsTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var Helper\Assets
+     */
+    protected $helper;
+
+    /**
+     * @var AssetsManager
+     */
+    protected $assetsManager;
+
+    public function setUp()
+    {
+        $renderer = new Renderer();
+        $renderer->setHelperPluginManager(new HelperPluginManager(new ServiceManager));
+
+        $router = $this->getMockBuilder(RouteStackInterface::class)
+                         ->setMethods(['assemble'])
+                         ->getMockForAbstractClass();
+        $router->method('assemble')->will($this->returnCallback(function ($params) {
+            $result = 'assets-cache';
+            if (isset($params['alias'])) {
+                $result .= '/alias-' . $params['alias'];
+            }
+            if (isset($params['prefix'])) {
+                $result .= '/prefix-' . $params['prefix'];
+            }
+            return $result . '/' . ltrim($params['asset'], '/');
+        }));
+        $renderer->plugin('url')->setRouter($router);
+
+        $this->assetsManager = new AssetsManager();
+        $this->assetsManager->setMimeResolver(new MimeResolver());
+        $this->helper = new Helper\Assets();
+        $this->helper
+                ->setAssetsManager($this->assetsManager)
+                ->setView($renderer)
+                ->setRouteName('someroute')
+                ->setMimeAttributes('text/css', []);
+    }
+
+    public function testCallUndefinedMethod()
+    {
+        $this->setExpectedException(Exception\BadMethodCallException::class, 'Method "Undefined" does not exist');
+        $this->helper->Undefined('');
+    }
+
+    public function testInvalidRouteName()
+    {
+        $this->setExpectedException(Exception\InvalidArgumentException::class, 'Using modules assets require the valid "routeName"');
+        $this->helper
+                ->setRouteName(null)
+                ->add('Module1::/css/foo.css')
+                ->render();
+    }
+
+    public function testToString()
+    {
+        $this->helper->add('/css/baz.css');
+        $this->assertEquals(
+            '<link href="/css/baz.css" type="text/css">' . "\n",
+            (string)$this->helper
+        );
+    }
+
+    public function testRender()
+    {
+        $this->helper
+                ->add('http://com.com/css/bat.css')
+                ->add('module-1::/foo.css')
+                ->add('/bar.css')
+                ->add('alias0');
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+            '<link href="http://com.com/css/bat.css" type="text/css">',
+            '<link href="/assets-cache/prefix-module-1/foo.css" type="text/css">',
+            '<link href="/bar.css" type="text/css">',
+            '<link href="/alias0" type="text/plain">',
+        ], $rendered);
+    }
+
+    public function testRenderWithRefferences()
+    {
+        $this->assetsManager
+                ->set('foo', [
+                    'assets' => [
+                        'foo1.css',
+                        'foo2.css',
+                     ],
+                ])
+                ->set('bar', [
+                    'assets' => [
+                        'bar1.css',
+                        'foo',
+                     ],
+                ]);
+        $this->helper->add('bar');
+
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+            '<link href="/assets-cache/alias-bar/bar1.css" type="text/css">',
+            '<link href="/assets-cache/alias-foo/foo1.css" type="text/css">',
+            '<link href="/assets-cache/alias-foo/foo2.css" type="text/css">',
+        ], $rendered);
+    }
+
+    public function testRenderWithRename()
+    {
+        $this->assetsManager
+                ->set('foo', [
+                    'assets' => [
+                        'style1.css' => [
+                            'source' => 'style1.less'
+                        ],
+                        'foo::style2.css' => [
+                            'source' => 'foo::style2.less'
+                        ],
+                        'style3.css' => [
+                            'source' => 'foo::style3.less'
+                        ],
+                     ],
+                ])
+                ->set('bar.css', [
+                    'source' => 'bar.less',
+                ])
+                ->set('bat.css', [
+                    'source' => 'bat.less',
+                ]);
+        $this->helper->add('foo');
+        $this->helper->add('bar.css');
+        $this->helper->add('bat.css');
+
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+            '<link href="/assets-cache/alias-foo/style1.css" type="text/css">',
+            '<link href="/assets-cache/alias-foo/prefix-foo/style2.css" type="text/css">',
+            '<link href="/assets-cache/alias-foo/style3.css" type="text/css">',
+            '<link href="/bar.css" type="text/css">',
+            '<link href="/bat.css" type="text/css">',
+        ], $rendered);
+    }
+
+    public function testRenderWithAssetsManager()
+    {
+        $this->assetsManager
+                ->set('external.css', [
+                    'source' => 'http://com.com/foo.css',
+                ])
+                ->set('/foo.css', [
+                    'source' => '/foo.less',
+                ])
+                ->set('foo', [
+                    'assets' => [
+                        '/bar.css',
+                        '/bat.css',
+                     ],
+                ])
+                ->set('module-1::/foo.css', [])
+                ->set('alias', [
+                    'assets' => [
+                        'module-2::/baz.css',
+                     ],
+                ]);
+        $this->helper
+                ->add('external.css')
+                ->add('foo.css')
+                ->add('foo')
+                ->add('module-1::/foo.css')
+                ->add('alias');
+
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+            '<link href="/external.css" type="text/css">',
+            '<link href="/foo.css" type="text/css">',
+            '<link href="/assets-cache/alias-foo/bar.css" type="text/css">',
+            '<link href="/assets-cache/alias-foo/bat.css" type="text/css">',
+            '<link href="/assets-cache/prefix-module-1/foo.css" type="text/css">',
+            '<link href="/assets-cache/alias-alias/prefix-module-2/baz.css" type="text/css">',
+        ], $rendered);
+    }
+
+    public function testRenderWithPriority()
+    {
+        $this->helper->add('/css/foo.css', 2);
+        $this->helper->add('/css/bar.css', -5);
+        $this->helper->add('/css/bat.css', 3);
+        $this->helper->add('/css/baz.css', 4);
+
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+                '<link href="/css/baz.css" type="text/css">',
+                '<link href="/css/bat.css" type="text/css">',
+                '<link href="/css/foo.css" type="text/css">',
+                '<link href="/css/bar.css" type="text/css">',
+            ],
+            $rendered
+        );
+    }
+
+    public function testRenderWithAttributes()
+    {
+        $this->assetsManager
+                ->set('bas.css', [
+                    'source' => '/css/bas.css',
+                    'attributes' => [
+                        'charset' => 'UTF-3',
+                    ],
+                ])
+                ->set('bat.css', [
+                    'source' => '/css/bat.css',
+                    'attributes' => [
+                        'charset' => 'UTF-4',
+                    ],
+                ])
+                ->set('list', [
+                    'assets' => [
+                        '/css/baz.css' => [
+                            'attributes' => [
+                                'charset' => 'UTF-6',
+                            ],
+                        ]
+                    ],
+                    'attributes' => [
+                        'charset' => 'UTF-7',
+                    ],
+                ]);
+
+        $this->helper
+                ->add('/css/foo.css', ['charset' => 'UTF-1'])
+                ->add('/css/bar.css',  ['charset' => 'UTF-2'])
+                ->add('bas.css',  ['hreflang' => 'UK-1'])
+                ->add('bat.css',  ['hreflang' => 'UK-2', 'charset' => 'UTF-5'])
+                ->add('list');
+
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+                '<link charset="UTF-1" href="/css/foo.css" type="text/css">',
+                '<link charset="UTF-2" href="/css/bar.css" type="text/css">',
+                '<link charset="UTF-3" href="/bas.css" hreflang="UK-1" type="text/css">',
+                '<link charset="UTF-5" href="/bat.css" hreflang="UK-2" type="text/css">',
+                '<link charset="UTF-7" href="/assets-cache/alias-list/css/baz.css" type="text/css">',
+            ],
+            $rendered
+        );
+    }
+
+    public function testRenderGroups()
+    {
+        $this->helper->add('/css/baz.css');
+        $this->helper->addFooter('/css/bar.css');
+
+        $this->assertEquals(
+            '<link href="/css/baz.css" type="text/css">' . "\n",
+            $this->helper->render()
+        );
+        $this->assertEquals(
+            '<link href="/css/bar.css" type="text/css">' . "\n",
+            $this->helper->renderFooter()
+        );
+    }
+
+    public function testRenderSameNameInDifferentGroups()
+    {
+        $this->assetsManager
+                ->set('foo.css', ['attributes' => ['charset' => 'UTF-1']])
+                ->set('bar.css', ['attributes' => ['charset' => 'UTF-2']]);
+        $this->assetsManager->setCurrentGroup('group2')
+                ->set('foo.css', ['attributes' => ['charset' => 'UTF-3']])
+                ->set('bar.css', ['attributes' => ['charset' => 'UTF-4']]);
+
+        $this->helper
+                ->add('foo.css')
+                ->add('bar.css');
+
+        $this->assetsManager->setCurrentGroup('default');
+
+        $this->assertEquals([
+                '<link charset="UTF-1" href="/foo.css" type="text/css">',
+                '<link charset="UTF-2" href="/bar.css" type="text/css">',
+            ],
+            explode("\n", $this->helper->render(), -1)
+        );
+
+        $rendered = new \ReflectionProperty($this->helper, 'rendered');
+        $rendered->setAccessible(true);
+        $rendered->setValue($this->helper, []);
+
+        $this->assetsManager->setCurrentGroup('group2');
+
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+                '<link charset="UTF-3" href="/foo.css" type="text/css">',
+                '<link charset="UTF-4" href="/bar.css" type="text/css">',
+            ],
+            $rendered
+        );
+    }
+
+    public function testRenderMimeDefaultAttributes()
+    {
+        $this->helper->setMimeAttributes('text/css', [
+            'rel'   => 'stylesheet',
+            'media' => 'screen',
+        ]);
+
+        $this->assertEquals(
+            '<link href="/style1.css" media="screen" rel="stylesheet" type="text/css">' . "\n",
+            (string)$this->helper->add('style1.css')
+        );
+    }
+
+    public function testRenderDuplicates()
+    {
+        $this->helper->add('style1.css');
+        $this->helper->add('style2.css');
+        $this->helper->add('style1.css');
+
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+                '<link href="/style1.css" type="text/css">',
+                '<link href="/style2.css" type="text/css">',
+            ],
+            $rendered
+        );
+    }
+
+    public function testRenderNotExistGroup()
+    {
+        $this->helper->addGroup1('style1.css');
+        $this->assertEquals('', $this->helper->render());
+    }
+
+    public function testRenderJavaScript()
+    {
+        $this->helper->add('style1.js', ['charset' => 'UTF-1']);
+        $rendered = explode("\n", $this->helper->render(), -1);
+        $this->assertEquals([
+                '<script type="application/javascript" charset="UTF-1" src="/style1.js"></script>',
+            ],
+            $rendered
+        );
+    }
+}


### PR DESCRIPTION
The `Assets` helper allow to add various resourses to html page, such as .css, .js, etc.
It can be configure in config files.
For page performance optimisation assets can be placed in top or bottom of page (or elsewhere).

Allow to build several link by one alias:
```
// CONFIG FILE:
'assets_manager' => [
  ...
  'several_assets' => [
    'assets' => [
      'foo.css',
      'bar.css',
      'jquery.js' => 'https://code.jquery.com/jquery-3.0.0.min.js',
    ],
  ],
  ...

// LAYOUT:
echo $this->assets()->add('several_assets');

// OUTPUT:
<link href="/foo.css" type="text/css">
<link href="/bar.css" type="text/css">
<script type="application/javascript" src="https://code.jquery.com/jquery-3.0.0.min.js"></script>
```

Also can possible change layout decoration 'on fly' :
```
// CONFIG FILE:
'assets_manager' => [
  'assets' => [
    'default' => [
      'layout.css' => 'foo.css',
    ],
    'my-theme' => [
      'layout.css' => 'bar.css',
    ],
  ...

// LAYOUT:
$this->assets()->add('layout.css');
if ('good weather') {
  $this->assets()->getAssetsManager()->setCurrentGroup('my-theme');
} else {
  $this->assets()->getAssetsManager()->setCurrentGroup('default');
}
// GOOD WEATHER OUTPUT:
<link href="/bar.css" type="text/css">
// NOT GOOD WEATHER OUTPUT:
<link href="/foo.css" type="text/css">

```