### PR TITLE
Added fallback for navigation container names in view helpers

### DIFF
--- a/src/Helper/Navigation/AbstractHelper.php
+++ b/src/Helper/Navigation/AbstractHelper.php
@@ -251,6 +251,21 @@ abstract class AbstractHelper extends View\Helper\AbstractHtmlElement implements
                 ));
             }
 
+            // Fallback
+            if (in_array($container, ['default', 'navigation'], true)) {
+                // Uses class name
+                if ($services->has(Navigation\Navigation::class)) {
+                    $container = $services->get(Navigation\Navigation::class);
+                    return;
+                }
+
+                // Uses old service name
+                if ($services->has('navigation')) {
+                    $container = $services->get('navigation');
+                    return;
+                }
+            }
+
             /**
              * Load the navigation container from the root service locator
              */

--- a/test/Helper/Navigation/AbstractHelperTest.php
+++ b/test/Helper/Navigation/AbstractHelperTest.php
@@ -9,6 +9,9 @@
 
 namespace ZendTest\View\Helper\Navigation;
 
+use Zend\Navigation\Navigation;
+use Zend\ServiceManager\ServiceManager;
+
 class AbstractHelperTest extends AbstractTest
 {
     /**
@@ -80,5 +83,30 @@ class AbstractHelperTest extends AbstractTest
     public function testEventManagerIsNullByDefault()
     {
         $this->assertNull($this->_helper->getEventManager());
+    }
+
+    public function testFallBackForContainerNames()
+    {
+        // Register navigation service with name equal to the documentation
+        $this->serviceManager->setAllowOverride(true);
+        $this->serviceManager->setService(
+            'navigation',
+            $this->serviceManager->get('Navigation')
+        );
+        $this->serviceManager->setAllowOverride(false);
+
+        $this->_helper->setServiceLocator($this->serviceManager);
+
+        $this->_helper->setContainer('navigation');
+        $this->assertInstanceOf(
+            Navigation::class,
+            $this->_helper->getContainer()
+        );
+
+        $this->_helper->setContainer('default');
+        $this->assertInstanceOf(
+            Navigation::class,
+            $this->_helper->getContainer()
+        );
     }
 }

--- a/test/Helper/Navigation/AbstractTest.php
+++ b/test/Helper/Navigation/AbstractTest.php
@@ -30,7 +30,7 @@ use ZendTest\View\Helper\TestAsset;
 abstract class AbstractTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var
+     * @var ServiceManager
      */
     protected $serviceManager;
 


### PR DESCRIPTION
- calling the navigation helper with a parameter `navigation` is confusing
- name do not corresponds to the documentation
- old name `default` can be used

Related to an issue of zend-navigation: zendframework/zend-navigation#43