### PR TITLE
PhpRendererStrategy should be able to handle an event w/o a response

### DIFF
--- a/src/Strategy/PhpRendererStrategy.php
+++ b/src/Strategy/PhpRendererStrategy.php
@@ -103,12 +103,12 @@ class PhpRendererStrategy extends AbstractListenerAggregate
     public function injectResponse(ViewEvent $e)
     {
         $renderer = $e->getRenderer();
-        if ($renderer !== $this->renderer) {
+        $response = $e->getResponse();
+        if ($renderer !== $this->renderer || $response === null) {
             return;
         }
 
         $result   = $e->getResult();
-        $response = $e->getResponse();
 
         // Set content
         // If content is empty, check common placeholders to determine if they are

--- a/test/Strategy/PhpRendererStrategyTest.php
+++ b/test/Strategy/PhpRendererStrategyTest.php
@@ -21,6 +21,9 @@ class PhpRendererStrategyTest extends TestCase
 {
     use EventListenerIntrospectionTrait;
 
+    /** @var PhpRendererStrategy */
+    private $strategy;
+
     public function setUp()
     {
         $this->renderer = new PhpRenderer;
@@ -167,5 +170,15 @@ class PhpRendererStrategyTest extends TestCase
         $this->assertCount(0, $listeners);
         $listeners = iterator_to_array($this->getListenersForEvent('response', $events));
         $this->assertCount(0, $listeners);
+    }
+
+    public function testInjectResponseWorksWithAnEventWithNoResponse()
+    {
+        $e = new ViewEvent();
+        $e->setRenderer($this->strategy->getRenderer());
+
+        $this->strategy->injectResponse($e);
+
+        $this->assertNull($e->getResponse());
     }
 }


### PR DESCRIPTION
ViewEvent#getResponse() may return null, but PhpRendererStrategy#injectResponse() didn't handle that case.