### PR TITLE
Override specific zend-servicemanager integration tests

### DIFF
--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -83,4 +83,24 @@ class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf(Breadcrumbs::class, $helper);
         $this->assertSame($services, $helper->getServiceLocator());
     }
+
+    /**
+     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     */
+    public function testRegisteringInvalidElementRaisesException()
+    {
+        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->getPluginManager()->setService('test', $this);
+    }
+
+    /**
+     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     */
+    public function testLoadingInvalidElementRaisesException()
+    {
+        $manager = $this->getPluginManager();
+        $manager->setInvokableClass('test', get_class($this));
+        $this->setExpectedException($this->getServiceNotFoundException());
+        $manager->get('test');
+    }
 }

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -89,4 +89,24 @@ class HelperPluginManagerCompatibilityTest extends TestCase
     {
         $this->markTestSkipped('instanceOf is not used with this implementation');
     }
+
+    /**
+     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     */
+    public function testRegisteringInvalidElementRaisesException()
+    {
+        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->getPluginManager()->setService('test', $this);
+    }
+
+    /**
+     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     */
+    public function testLoadingInvalidElementRaisesException()
+    {
+        $manager = $this->getPluginManager();
+        $manager->setInvokableClass('test', get_class($this));
+        $this->setExpectedException($this->getServiceNotFoundException());
+        $manager->get('test');
+    }
 }


### PR DESCRIPTION
To provide compatibility for PHPUnit 4.8, which is still necessary due to the PHP 5.5 requirement in this package.

This allows the tests against LATEST to pass on all versions.

A later update against the develop branch will bump the PHPUnit version to `^5.7 || ^6.0`, and the PHP version to `5.6 || 7.0`, allowing removal of these test overrides.