### PR TITLE
Upgrade to PHP 5.6 and PHPUnit 5.7/6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
   - composer self-update
 
 install:
-  - travis_retry composer install $COMPOSER_ARGS
+  - travis_retry composer install $COMPOSER_ARGS --ignore-platform-reqs
   - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer require --dev --no-update $COMPOSER_ARGS $LATEST_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
+    - COMPOSER_ARGS="--no-interaction"
+    - COVERAGE_DEPS="satooshi/php-coveralls"
+    - LEGACY_DEPS="phpunit/phpunit"
     - LATEST_DEPS="zendframework/zend-mvc-plugin-flashmessenger zendframework/zend-mvc-i18n zendframework/zend-mvc-console"
     - SITE_URL=https://zendframework.github.io/zend-view
     - GH_USER_NAME="Matthew Weier O'Phinney"
@@ -25,16 +27,6 @@ env:
 
 matrix:
   include:
-    - php: 5.5
-      env:
-        - DEPS=lowest
-    - php: 5.5
-      env:
-        - CS_CHECK=true
-        - DEPS=locked
-    - php: 5.5
-      env:
-        - DEPS=latest
     - php: 5.6
       env:
         - DEPS=lowest
@@ -78,10 +70,11 @@ before_install:
 
 install:
   - travis_retry composer install $COMPOSER_ARGS
+  - if [[ $TRAVIS_PHP_VERSION =~ ^5.6 ]]; then travis_retry composer update $COMPOSER_ARGS --with-dependencies $LEGACY_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer require --dev --no-update $COMPOSER_ARGS $LATEST_DEPS ; fi
   - if [[ $DEPS == 'latest' ]]; then travis_retry composer update $COMPOSER_ARGS ; fi
   - if [[ $DEPS == 'lowest' ]]; then travis_retry composer update --prefer-lowest --prefer-stable $COMPOSER_ARGS ; fi
-  - if [[ $TEST_COVERAGE == 'true' ]]; then composer require --dev --no-update satooshi/php-coveralls ; fi
+  - if [[ $TEST_COVERAGE == 'true' ]]; then travis_retry composer require --dev $COMPOSER_ARGS $COVERAGE_DEPS ; fi
   - composer show --installed
 
 script:

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,10 @@
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
+        "phpunit/phpunit": "^5.7||^6.0",
         "zendframework/zend-authentication": "^2.5",
         "zendframework/zend-cache": "^2.6.1",
+        "zendframework/zend-coding-standard": "~1.0.0",
         "zendframework/zend-config": "^2.6",
         "zendframework/zend-console": "^2.6",
         "zendframework/zend-escaper": "^2.5",
@@ -39,9 +41,7 @@
         "zendframework/zend-serializer": "^2.6.1",
         "zendframework/zend-session": "^2.6.2",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-        "zendframework/zend-uri": "^2.5",
-        "phpunit/phpunit": "^5.7||^6.0",
-        "zendframework/zend-coding-standard": "~1.0.0"
+        "zendframework/zend-uri": "^2.5"
     },
     "suggest": {
         "zendframework/zend-authentication": "Zend\\Authentication component",
@@ -60,6 +60,9 @@
     },
     "minimum-stability": "dev",
     "prefer-stable": true,
+    "config": {
+        "sort-packages": "true"
+    },
     "extra": {
         "branch-alias": {
             "dev-master": "2.8-dev",

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^5.7||^6.0",
+        "phpunit/phpunit": "^5.7.15 || ^6.0.8",
         "zendframework/zend-authentication": "^2.5",
         "zendframework/zend-cache": "^2.6.1",
         "zendframework/zend-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         }
     },
     "require": {
-        "php": "^5.5 || ^7.0",
+        "php": "^5.6 || ^7.0",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
         "zendframework/zend-loader": "^2.5",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
@@ -40,7 +40,7 @@
         "zendframework/zend-session": "^2.6.2",
         "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
         "zendframework/zend-uri": "^2.5",
-        "phpunit/phpunit": "^4.6",
+        "phpunit/phpunit": "^5.7||^6.0",
         "zendframework/zend-coding-standard": "~1.0.0"
     },
     "suggest": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "dc5cc91da6f6b28ac93af37161b9a923",
-    "content-hash": "cdfe6624614ef59302978b674ebf587c",
+    "content-hash": "7ca25431817bc1390556cea387634243",
     "packages": [
         {
             "name": "zendframework/zend-eventmanager",
@@ -59,7 +58,7 @@
                 "events",
                 "zf2"
             ],
-            "time": "2016-02-18 20:53:00"
+            "time": "2016-02-18T20:53:00+00:00"
         },
         {
             "name": "zendframework/zend-loader",
@@ -103,7 +102,7 @@
                 "loader",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:47"
+            "time": "2015-06-03T14:05:47+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
@@ -148,7 +147,7 @@
                 "stdlib",
                 "zf2"
             ],
-            "time": "2016-02-03 16:53:37"
+            "time": "2016-02-03T16:53:37+00:00"
         }
     ],
     "packages-dev": [
@@ -177,7 +176,7 @@
                 "MIT"
             ],
             "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
-            "time": "2014-12-30 15:22:37"
+            "time": "2014-12-30T15:22:37+00:00"
         },
         {
             "name": "doctrine/instantiator",
@@ -231,41 +230,132 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2015-06-14 21:17:01"
+            "time": "2015-06-14T21:17:01+00:00"
         },
         {
-            "name": "phpdocumentor/reflection-docblock",
-            "version": "2.0.4",
+            "name": "myclabs/deep-copy",
+            "version": "1.6.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8"
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/d68dbdc53dc358a816f00b300704702b2eaff7b8",
-                "reference": "d68dbdc53dc358a816f00b300704702b2eaff7b8",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/5a5a9fc8025a08d8919be87d6884d5a92520cefe",
+                "reference": "5a5a9fc8025a08d8919be87d6884d5a92520cefe",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "doctrine/collections": "1.*",
+                "phpunit/phpunit": "~4.1"
             },
-            "suggest": {
-                "dflydev/markdown": "~1.0",
-                "erusev/parsedown": "~1.0"
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "homepage": "https://github.com/myclabs/DeepCopy",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "time": "2017-01-26T22:05:40+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-common",
+            "version": "1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "reference": "144c307535e82c8fdcaacbcfc1d6d8eeb896687c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "1.0.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "phpDocumentor": [
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "time": "2015-12-27T11:43:31+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "3.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "reference": "8331b5efe816ae05461b7ca1e721c01b46bafb3e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0@dev",
+                "phpdocumentor/type-resolver": "^0.2.0",
+                "webmozart/assert": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^4.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
                         "src/"
                     ]
                 }
@@ -277,39 +367,88 @@
             "authors": [
                 {
                     "name": "Mike van Riel",
-                    "email": "mike.vanriel@naenius.com"
+                    "email": "me@mikevanriel.com"
                 }
             ],
-            "time": "2015-02-03 12:10:50"
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "time": "2016-09-30T07:12:33+00:00"
         },
         {
-            "name": "phpspec/prophecy",
-            "version": "v1.6.0",
+            "name": "phpdocumentor/type-resolver",
+            "version": "0.2.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972"
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/3c91bdf81797d725b14cb62906f9a4ce44235972",
-                "reference": "3c91bdf81797d725b14cb62906f9a4ce44235972",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "reference": "e224fb2ea2fba6d3ad6fdaef91cd09a172155ccb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5",
+                "phpdocumentor/reflection-common": "^1.0"
+            },
+            "require-dev": {
+                "mockery/mockery": "^0.9.4",
+                "phpunit/phpunit": "^5.2||^4.8.24"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "time": "2016-11-25T06:54:22+00:00"
+        },
+        {
+            "name": "phpspec/prophecy",
+            "version": "v1.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpspec/prophecy.git",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/93d39f1f7f9326d746203c7c056f300f7f126073",
+                "reference": "93d39f1f7f9326d746203c7c056f300f7f126073",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
                 "php": "^5.3|^7.0",
-                "phpdocumentor/reflection-docblock": "~2.0",
-                "sebastian/comparator": "~1.1",
-                "sebastian/recursion-context": "~1.0"
+                "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
+                "sebastian/comparator": "^1.1|^2.0",
+                "sebastian/recursion-context": "^1.0|^2.0|^3.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "~2.0"
+                "phpspec/phpspec": "^2.5|^3.2",
+                "phpunit/phpunit": "^4.8 || ^5.6.5"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.5.x-dev"
+                    "dev-master": "1.6.x-dev"
                 }
             },
             "autoload": {
@@ -342,43 +481,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2016-02-15 07:46:21"
+            "time": "2017-03-02T20:05:34+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "2.2.4",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979"
+                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/eabf68b476ac7d0f73793aada060f1c1a9bf8979",
-                "reference": "eabf68b476ac7d0f73793aada060f1c1a9bf8979",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
+                "reference": "4e99e1c4f9b05cbf4d6e84b100b3ff4107cf8cd1",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "phpunit/php-file-iterator": "~1.3",
-                "phpunit/php-text-template": "~1.2",
-                "phpunit/php-token-stream": "~1.3",
-                "sebastian/environment": "^1.3.2",
-                "sebastian/version": "~1.0"
+                "ext-dom": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.0",
+                "phpunit/php-file-iterator": "^1.3",
+                "phpunit/php-text-template": "^1.2",
+                "phpunit/php-token-stream": "^1.4.11 || ^2.0",
+                "sebastian/code-unit-reverse-lookup": "^1.0",
+                "sebastian/environment": "^2.0",
+                "sebastian/version": "^2.0"
             },
             "require-dev": {
-                "ext-xdebug": ">=2.1.4",
-                "phpunit/phpunit": "~4"
+                "ext-xdebug": "^2.5",
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
-                "ext-dom": "*",
-                "ext-xdebug": ">=2.2.1",
-                "ext-xmlwriter": "*"
+                "ext-xdebug": "^2.5.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.2.x-dev"
+                    "dev-master": "5.0.x-dev"
                 }
             },
             "autoload": {
@@ -404,20 +544,20 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2015-10-06 15:47:00"
+            "time": "2017-03-06T14:22:16+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0"
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
-                "reference": "6150bf2c35d3fc379e50c7602b75caceaa39dbf0",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
+                "reference": "3cc8f69b3028d0f96a9078e6295d86e9bf019be5",
                 "shasum": ""
             },
             "require": {
@@ -451,7 +591,7 @@
                 "filesystem",
                 "iterator"
             ],
-            "time": "2015-06-21 13:08:43"
+            "time": "2016-10-03T07:40:28+00:00"
         },
         {
             "name": "phpunit/php-text-template",
@@ -492,26 +632,34 @@
             "keywords": [
                 "template"
             ],
-            "time": "2015-06-21 13:50:34"
+            "time": "2015-06-21T13:50:34+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.7",
+            "version": "1.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b"
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
-                "reference": "3e82f4e9fc92665fafd9157568e4dcb01d014e5b",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -533,20 +681,20 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2015-06-21 08:01:12"
+            "time": "2017-02-26T11:10:40+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "1.4.8",
+            "version": "1.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da"
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
-                "reference": "3144ae21711fb6cac0b1ab4cbe63b75ce3d4e8da",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/e03f8f67534427a787e21a385a67ec3ca6978ea7",
+                "reference": "e03f8f67534427a787e21a385a67ec3ca6978ea7",
                 "shasum": ""
             },
             "require": {
@@ -582,45 +730,55 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2015-09-15 10:49:45"
+            "time": "2017-02-27T10:12:30+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "4.8.28",
+            "version": "6.0.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225"
+                "reference": "8a536f409ebae632b92b7e7288e068248fe365ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/558a3a0d28b4cb7e4a593a4fbd2220e787076225",
-                "reference": "558a3a0d28b4cb7e4a593a4fbd2220e787076225",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/8a536f409ebae632b92b7e7288e068248fe365ed",
+                "reference": "8a536f409ebae632b92b7e7288e068248fe365ed",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-json": "*",
-                "ext-pcre": "*",
-                "ext-reflection": "*",
-                "ext-spl": "*",
-                "php": ">=5.3.3",
-                "phpspec/prophecy": "^1.3.1",
-                "phpunit/php-code-coverage": "~2.1",
-                "phpunit/php-file-iterator": "~1.4",
-                "phpunit/php-text-template": "~1.2",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "myclabs/deep-copy": "^1.3",
+                "php": "^7.0",
+                "phpspec/prophecy": "^1.7",
+                "phpunit/php-code-coverage": "^5.0",
+                "phpunit/php-file-iterator": "^1.4",
+                "phpunit/php-text-template": "^1.2",
                 "phpunit/php-timer": "^1.0.6",
-                "phpunit/phpunit-mock-objects": "~2.3",
-                "sebastian/comparator": "~1.1",
-                "sebastian/diff": "~1.2",
-                "sebastian/environment": "~1.3",
-                "sebastian/exporter": "~1.2",
-                "sebastian/global-state": "~1.0",
-                "sebastian/version": "~1.0",
-                "symfony/yaml": "~2.1|~3.0"
+                "phpunit/phpunit-mock-objects": "^4.0",
+                "sebastian/comparator": "^2.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/environment": "^2.0",
+                "sebastian/exporter": "^3.0",
+                "sebastian/global-state": "^1.1 || ^2.0",
+                "sebastian/object-enumerator": "^3.0.2",
+                "sebastian/resource-operations": "^1.0",
+                "sebastian/version": "^2.0"
+            },
+            "conflict": {
+                "phpdocumentor/reflection-docblock": "3.0.2",
+                "phpunit/dbunit": "<3.0"
+            },
+            "require-dev": {
+                "ext-pdo": "*"
             },
             "suggest": {
-                "phpunit/php-invoker": "~1.1"
+                "ext-xdebug": "*",
+                "phpunit/php-invoker": "^1.1"
             },
             "bin": [
                 "phpunit"
@@ -628,7 +786,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.8.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -654,30 +812,33 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2016-11-14 06:25:28"
+            "time": "2017-03-19T16:54:28+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "2.3.8",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983"
+                "reference": "eabce450df194817a7d7e27e19013569a903a2bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/ac8e7a3db35738d56ee9a76e78a4e03d97628983",
-                "reference": "ac8e7a3db35738d56ee9a76e78a4e03d97628983",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/eabce450df194817a7d7e27e19013569a903a2bf",
+                "reference": "eabce450df194817a7d7e27e19013569a903a2bf",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.2",
-                "php": ">=5.3.3",
-                "phpunit/php-text-template": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^7.0",
+                "phpunit/php-text-template": "^1.2",
+                "sebastian/exporter": "^3.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<6.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -685,7 +846,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3.x-dev"
+                    "dev-master": "4.0.x-dev"
                 }
             },
             "autoload": {
@@ -710,7 +871,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2015-10-02 06:51:40"
+            "time": "2017-03-03T06:30:20+00:00"
         },
         {
             "name": "psr/http-message",
@@ -759,7 +920,7 @@
                 "request",
                 "response"
             ],
-            "time": "2015-05-04 20:22:00"
+            "time": "2015-05-04T20:22:00+00:00"
         },
         {
             "name": "psr/log",
@@ -797,34 +958,79 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2012-12-21 11:40:51"
+            "time": "2012-12-21T11:40:51+00:00"
         },
         {
-            "name": "sebastian/comparator",
-            "version": "1.2.0",
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "1.0.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22"
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/937efb279bd37a375bcadf584dec0726f84dbf22",
-                "reference": "937efb279bd37a375bcadf584dec0726f84dbf22",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
+                "reference": "4419fcdb5eabb9caa61a27c7a1db532a6b55dd18",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/diff": "~1.2",
-                "sebastian/exporter": "~1.2"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.7 || ^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "time": "2017-03-04T06:30:41+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/20f84f468cb67efee293246e6a09619b891f55f0",
+                "reference": "20f84f468cb67efee293246e6a09619b891f55f0",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0",
+                "sebastian/diff": "^1.2",
+                "sebastian/exporter": "^3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -861,7 +1067,7 @@
                 "compare",
                 "equality"
             ],
-            "time": "2015-07-26 15:48:44"
+            "time": "2017-03-03T06:26:08+00:00"
         },
         {
             "name": "sebastian/diff",
@@ -913,32 +1119,32 @@
             "keywords": [
                 "diff"
             ],
-            "time": "2015-12-08 07:14:41"
+            "time": "2015-12-08T07:14:41+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "1.3.5",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf"
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
-                "reference": "dc7a29032cf72b54f36dac15a1ca5b3a1b6029bf",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
+                "reference": "5795ffe5dc5b02460c3e34222fee8cbe245d8fac",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^5.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3.x-dev"
+                    "dev-master": "2.0.x-dev"
                 }
             },
             "autoload": {
@@ -963,33 +1169,34 @@
                 "environment",
                 "hhvm"
             ],
-            "time": "2016-02-26 18:40:46"
+            "time": "2016-11-26T07:53:53+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "1.2.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e"
+                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/7ae5513327cb536431847bcc0c10edba2701064e",
-                "reference": "7ae5513327cb536431847bcc0c10edba2701064e",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/b82d077cb3459e393abcf4867ae8f7230dcb51f6",
+                "reference": "b82d077cb3459e393abcf4867ae8f7230dcb51f6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3",
-                "sebastian/recursion-context": "~1.0"
+                "php": "^7.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "ext-mbstring": "*",
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.2.x-dev"
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1029,7 +1236,7 @@
                 "export",
                 "exporter"
             ],
-            "time": "2015-06-21 07:55:53"
+            "time": "2017-03-03T06:25:06+00:00"
         },
         {
             "name": "sebastian/global-state",
@@ -1080,32 +1287,124 @@
             "keywords": [
                 "global state"
             ],
-            "time": "2015-10-12 03:26:01"
+            "time": "2015-10-12T03:26:01+00:00"
         },
         {
-            "name": "sebastian/recursion-context",
-            "version": "1.0.2",
+            "name": "sebastian/object-enumerator",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791"
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/913401df809e99e4f47b27cdd781f4a258d58791",
-                "reference": "913401df809e99e4f47b27cdd781f4a258d58791",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/31dd3379d16446c5d86dec32ab1ad1f378581ad8",
+                "reference": "31dd3379d16446c5d86dec32ab1ad1f378581ad8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.3"
+                "php": "^7.0",
+                "sebastian/object-reflector": "^1.0",
+                "sebastian/recursion-context": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.4"
+                "phpunit/phpunit": "^6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0.x-dev"
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "time": "2017-03-12T15:17:29+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "afd5797e7af7c9f529879ad5e8e8abe126c89dab"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/afd5797e7af7c9f529879ad5e8e8abe126c89dab",
+                "reference": "afd5797e7af7c9f529879ad5e8e8abe126c89dab",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "time": "2017-03-16T14:05:21+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "reference": "5b0cd723502bac3b006cbf3dbf7a1e3fcefe4fa8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^6.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
                 }
             },
             "autoload": {
@@ -1133,23 +1432,73 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
-            "time": "2015-11-11 19:50:13"
+            "time": "2017-03-03T06:23:57+00:00"
         },
         {
-            "name": "sebastian/version",
-            "version": "1.0.6",
+            "name": "sebastian/resource-operations",
+            "version": "1.0.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6"
+                "url": "https://github.com/sebastianbergmann/resource-operations.git",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
-                "reference": "58b3a85e7999757d6ad81c787a1fbf5ff6c628c6",
+                "url": "https://api.github.com/repos/sebastianbergmann/resource-operations/zipball/ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
+                "reference": "ce990bb21759f94aeafd30209e8cfcdfa8bc3f52",
                 "shasum": ""
             },
+            "require": {
+                "php": ">=5.6.0"
+            },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides a list of PHP built-in functions that operate on resources",
+            "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "time": "2015-07-28T20:34:47+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "reference": "99732be0ddb3361e16ad77b68ba41efc8e979019",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "classmap": [
                     "src/"
@@ -1168,7 +1517,7 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
-            "time": "2015-06-21 13:59:46"
+            "time": "2016-10-03T07:35:21+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -1246,38 +1595,39 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2016-09-01 23:53:02"
+            "time": "2016-09-01T23:53:02+00:00"
         },
         {
-            "name": "symfony/yaml",
-            "version": "v3.0.3",
+            "name": "webmozart/assert",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/yaml.git",
-                "reference": "b5ba64cd67ecd6887f63868fa781ca094bd1377c"
+                "url": "https://github.com/webmozart/assert.git",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/b5ba64cd67ecd6887f63868fa781ca094bd1377c",
-                "reference": "b5ba64cd67ecd6887f63868fa781ca094bd1377c",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/2db61e59ff05fe5126d152bd0655c9ea113e550f",
+                "reference": "2db61e59ff05fe5126d152bd0655c9ea113e550f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.5.9"
+                "php": "^5.3.3 || ^7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.6",
+                "sebastian/version": "^1.0.1"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "1.3-dev"
                 }
             },
             "autoload": {
                 "psr-4": {
-                    "Symfony\\Component\\Yaml\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
+                    "Webmozart\\Assert\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1285,17 +1635,17 @@
             ],
             "authors": [
                 {
-                    "name": "Fabien Potencier",
-                    "email": "fabien@symfony.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
                 }
             ],
-            "description": "Symfony Yaml Component",
-            "homepage": "https://symfony.com",
-            "time": "2016-02-23 15:16:06"
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "time": "2016-11-23T20:04:58+00:00"
         },
         {
             "name": "zendframework/zend-authentication",
@@ -1357,7 +1707,7 @@
                 "Authentication",
                 "zf2"
             ],
-            "time": "2016-02-28 15:02:34"
+            "time": "2016-02-28T15:02:34+00:00"
         },
         {
             "name": "zendframework/zend-cache",
@@ -1420,7 +1770,7 @@
                 "cache",
                 "zf2"
             ],
-            "time": "2016-02-12 16:26:56"
+            "time": "2016-02-12T16:26:56+00:00"
         },
         {
             "name": "zendframework/zend-coding-standard",
@@ -1449,7 +1799,7 @@
                 "Coding Standard",
                 "zf"
             ],
-            "time": "2016-11-09 21:30:43"
+            "time": "2016-11-09T21:30:43+00:00"
         },
         {
             "name": "zendframework/zend-config",
@@ -1505,7 +1855,7 @@
                 "config",
                 "zf2"
             ],
-            "time": "2016-02-04 23:01:10"
+            "time": "2016-02-04T23:01:10+00:00"
         },
         {
             "name": "zendframework/zend-console",
@@ -1557,7 +1907,7 @@
                 "console",
                 "zf2"
             ],
-            "time": "2016-02-09 17:15:12"
+            "time": "2016-02-09T17:15:12+00:00"
         },
         {
             "name": "zendframework/zend-diactoros",
@@ -1607,7 +1957,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2016-03-17 14:10:10"
+            "time": "2016-03-17T14:10:10+00:00"
         },
         {
             "name": "zendframework/zend-escaper",
@@ -1651,7 +2001,7 @@
                 "escaper",
                 "zf2"
             ],
-            "time": "2015-06-03 14:05:37"
+            "time": "2015-06-03T14:05:37+00:00"
         },
         {
             "name": "zendframework/zend-feed",
@@ -1712,7 +2062,7 @@
                 "feed",
                 "zf2"
             ],
-            "time": "2016-02-11 18:54:29"
+            "time": "2016-02-11T18:54:29+00:00"
         },
         {
             "name": "zendframework/zend-filter",
@@ -1768,7 +2118,7 @@
                 "filter",
                 "zf2"
             ],
-            "time": "2016-02-08 18:02:37"
+            "time": "2016-02-08T18:02:37+00:00"
         },
         {
             "name": "zendframework/zend-form",
@@ -1839,7 +2189,7 @@
                 "form",
                 "zf2"
             ],
-            "time": "2016-02-22 21:41:46"
+            "time": "2016-02-22T21:41:46+00:00"
         },
         {
             "name": "zendframework/zend-http",
@@ -1889,7 +2239,7 @@
                 "http",
                 "zf2"
             ],
-            "time": "2016-02-04 20:36:48"
+            "time": "2016-02-04T20:36:48+00:00"
         },
         {
             "name": "zendframework/zend-hydrator",
@@ -1947,7 +2297,7 @@
                 "hydrator",
                 "zf2"
             ],
-            "time": "2016-02-18 22:31:17"
+            "time": "2016-02-18T22:31:17+00:00"
         },
         {
             "name": "zendframework/zend-i18n",
@@ -2010,7 +2360,7 @@
                 "i18n",
                 "zf2"
             ],
-            "time": "2016-02-10 22:29:02"
+            "time": "2016-02-10T22:29:02+00:00"
         },
         {
             "name": "zendframework/zend-inputfilter",
@@ -2061,7 +2411,7 @@
                 "inputfilter",
                 "zf2"
             ],
-            "time": "2016-02-18 19:49:24"
+            "time": "2016-02-18T19:49:24+00:00"
         },
         {
             "name": "zendframework/zend-json",
@@ -2116,7 +2466,7 @@
                 "json",
                 "zf2"
             ],
-            "time": "2016-02-04 21:20:26"
+            "time": "2016-02-04T21:20:26+00:00"
         },
         {
             "name": "zendframework/zend-log",
@@ -2180,7 +2530,7 @@
                 "logging",
                 "zf2"
             ],
-            "time": "2016-02-18 17:20:07"
+            "time": "2016-02-18T17:20:07+00:00"
         },
         {
             "name": "zendframework/zend-math",
@@ -2230,7 +2580,7 @@
                 "math",
                 "zf2"
             ],
-            "time": "2016-02-02 23:15:14"
+            "time": "2016-02-02T23:15:14+00:00"
         },
         {
             "name": "zendframework/zend-modulemanager",
@@ -2288,7 +2638,7 @@
                 "modulemanager",
                 "zf2"
             ],
-            "time": "2016-02-28 04:45:34"
+            "time": "2016-02-28T04:45:34+00:00"
         },
         {
             "name": "zendframework/zend-mvc",
@@ -2378,7 +2728,7 @@
                 "mvc",
                 "zf2"
             ],
-            "time": "2016-03-08 18:55:43"
+            "time": "2016-03-08T18:55:43+00:00"
         },
         {
             "name": "zendframework/zend-navigation",
@@ -2441,7 +2791,7 @@
                 "navigation",
                 "zf2"
             ],
-            "time": "2016-02-24 21:33:58"
+            "time": "2016-02-24T21:33:58+00:00"
         },
         {
             "name": "zendframework/zend-paginator",
@@ -2501,7 +2851,7 @@
                 "paginator",
                 "zf2"
             ],
-            "time": "2016-02-23 17:41:20"
+            "time": "2016-02-23T17:41:20+00:00"
         },
         {
             "name": "zendframework/zend-permissions-acl",
@@ -2550,7 +2900,7 @@
                 "acl",
                 "zf2"
             ],
-            "time": "2016-02-03 21:46:45"
+            "time": "2016-02-03T21:46:45+00:00"
         },
         {
             "name": "zendframework/zend-psr7bridge",
@@ -2599,7 +2949,7 @@
                 "psr",
                 "psr-7"
             ],
-            "time": "2015-12-15 21:35:42"
+            "time": "2015-12-15T21:35:42+00:00"
         },
         {
             "name": "zendframework/zend-router",
@@ -2657,7 +3007,7 @@
                 "routing",
                 "zf2"
             ],
-            "time": "2016-04-18 17:04:31"
+            "time": "2016-04-18T17:04:31+00:00"
         },
         {
             "name": "zendframework/zend-serializer",
@@ -2709,7 +3059,7 @@
                 "serializer",
                 "zf2"
             ],
-            "time": "2016-02-03 18:36:25"
+            "time": "2016-02-03T18:36:25+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
@@ -2761,7 +3111,7 @@
                 "servicemanager",
                 "zf"
             ],
-            "time": "2016-02-02 14:13:42"
+            "time": "2016-02-02T14:13:42+00:00"
         },
         {
             "name": "zendframework/zend-session",
@@ -2821,7 +3171,7 @@
                 "session",
                 "zf2"
             ],
-            "time": "2016-02-25 19:32:38"
+            "time": "2016-02-25T19:32:38+00:00"
         },
         {
             "name": "zendframework/zend-uri",
@@ -2868,7 +3218,7 @@
                 "uri",
                 "zf2"
             ],
-            "time": "2016-02-17 22:38:51"
+            "time": "2016-02-17T22:38:51+00:00"
         },
         {
             "name": "zendframework/zend-validator",
@@ -2935,7 +3285,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2016-02-17 17:59:34"
+            "time": "2016-02-17T17:59:34+00:00"
         }
     ],
     "aliases": [],
@@ -2944,7 +3294,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^5.5 || ^7.0"
+        "php": "^5.6 || ^7.0"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7ca25431817bc1390556cea387634243",
+    "content-hash": "f03d323fe69107cef7eb95f499c1fcfc",
     "packages": [
         {
             "name": "zendframework/zend-eventmanager",

--- a/test/Helper/AbstractHtmlElementTest.php
+++ b/test/Helper/AbstractHtmlElementTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\View\Renderer\PhpRenderer;
 
 /**

--- a/test/Helper/AbstractTest.php
+++ b/test/Helper/AbstractTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ZendTest\View\Helper\TestAsset\ConcreteHelper;
 
 /**
@@ -30,7 +30,7 @@ class AbstractTest extends TestCase
 
     public function testViewSettersGetters()
     {
-        $viewMock = $this->getMock('Zend\View\Renderer\RendererInterface');
+        $viewMock = $this->getMockBuilder('Zend\View\Renderer\RendererInterface')->getMock();
 
         $this->helper->setView($viewMock);
         $this->assertEquals($viewMock, $this->helper->getView());

--- a/test/Helper/BasePathTest.php
+++ b/test/Helper/BasePathTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\View\Helper\BasePath;
 
 /**

--- a/test/Helper/CycleTest.php
+++ b/test/Helper/CycleTest.php
@@ -17,7 +17,7 @@ use Zend\View\Helper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class CycleTest extends \PHPUnit_Framework_TestCase
+class CycleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Helper\Cycle

--- a/test/Helper/DeclareVarsTest.php
+++ b/test/Helper/DeclareVarsTest.php
@@ -16,7 +16,7 @@ use Zend\View\Helper\DeclareVars;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class DeclareVarsTest extends \PHPUnit_Framework_TestCase
+class DeclareVarsTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/test/Helper/DoctypeTest.php
+++ b/test/Helper/DoctypeTest.php
@@ -17,7 +17,7 @@ use Zend\View\Helper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class DoctypeTest extends \PHPUnit_Framework_TestCase
+class DoctypeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Helper\Doctype

--- a/test/Helper/EscapeCssTest.php
+++ b/test/Helper/EscapeCssTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\View\Helper\EscapeCss as EscapeHelper;
 
@@ -66,7 +66,7 @@ class EscapeCssTest extends TestCase
 
     public function testEscapehtmlCalledOnEscaperObject()
     {
-        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper = $this->getMockBuilder('\\Zend\\Escaper\\Escaper')->getMock();
         $escaper->expects($this->any())->method('escapeCss');
         $this->helper->setEscaper($escaper);
         $this->helper->__invoke('foo');

--- a/test/Helper/EscapeHtmlAttrTest.php
+++ b/test/Helper/EscapeHtmlAttrTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\View\Helper\EscapeHtmlAttr as EscapeHelper;
 
@@ -66,7 +66,7 @@ class EscapeHtmlAttrTest extends TestCase
 
     public function testEscapehtmlCalledOnEscaperObject()
     {
-        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper = $this->getMockBuilder('\\Zend\\Escaper\\Escaper')->getMock();
         $escaper->expects($this->any())->method('escapeHtmlAttr');
         $this->helper->setEscaper($escaper);
         $this->helper->__invoke('foo');

--- a/test/Helper/EscapeHtmlTest.php
+++ b/test/Helper/EscapeHtmlTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\View\Helper\EscapeHtml as EscapeHelper;
 
@@ -66,7 +66,7 @@ class EscapeHtmlTest extends TestCase
 
     public function testEscapehtmlCalledOnEscaperObject()
     {
-        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper = $this->getMockBuilder('\\Zend\\Escaper\\Escaper')->getMock();
         $escaper->expects($this->any())->method('escapeHtml');
         $this->helper->setEscaper($escaper);
         $this->helper->__invoke('foo');

--- a/test/Helper/EscapeJsTest.php
+++ b/test/Helper/EscapeJsTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\View\Helper\EscapeJs as EscapeHelper;
 
@@ -66,7 +66,7 @@ class EscapeJsTest extends TestCase
 
     public function testEscapehtmlCalledOnEscaperObject()
     {
-        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper = $this->getMockBuilder('\\Zend\\Escaper\\Escaper')->getMock();
         $escaper->expects($this->any())->method('escapeJs');
         $this->helper->setEscaper($escaper);
         $this->helper->__invoke('foo');

--- a/test/Helper/EscapeUrlTest.php
+++ b/test/Helper/EscapeUrlTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\View\Helper\EscapeUrl as EscapeHelper;
 
@@ -66,7 +66,7 @@ class EscapeUrlTest extends TestCase
 
     public function testEscapehtmlCalledOnEscaperObject()
     {
-        $escaper = $this->getMock('\\Zend\\Escaper\\Escaper');
+        $escaper = $this->getMockBuilder('\\Zend\\Escaper\\Escaper')->getMock();
         $escaper->expects($this->any())->method('escapeUrl');
         $this->helper->setEscaper($escaper);
         $this->helper->__invoke('foo');

--- a/test/Helper/FlashMessengerTest.php
+++ b/test/Helper/FlashMessengerTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Mvc\Controller\Plugin\FlashMessenger as V2PluginFlashMessenger;
 use Zend\Mvc\Controller\PluginManager;
 use Zend\Mvc\Plugin\FlashMessenger\FlashMessenger as V3PluginFlashMessenger;
@@ -169,17 +169,35 @@ class FlashMessengerTest extends TestCase
 
     public function testCanDisplayListOfMessages()
     {
+        $plugin = $this->prophesize($this->mvcPluginClass);
+        $plugin->getMessagesFromNamespace('info')->will(function () {
+            return [];
+        });
+        $plugin->addInfoMessage('bar-info')->will(function ($args) {
+            $this->getMessagesFromNamespace('info')->willReturn([$args[0]]);
+            return null;
+        });
+
+        $this->helper->setPluginFlashMessenger($plugin->reveal());
+
         $displayInfoAssertion = '';
         $displayInfo = $this->helper->render('info');
         $this->assertEquals($displayInfoAssertion, $displayInfo);
 
-        $this->seedMessages();
+        $helper = new FlashMessenger();
+        $helper->setPluginFlashMessenger($plugin->reveal());
+        $helper->addInfoMessage('bar-info');
+        unset($helper);
 
         $displayInfoAssertion = '<ul class="info"><li>bar-info</li></ul>';
         $displayInfo = $this->helper->render('info');
         $this->assertEquals($displayInfoAssertion, $displayInfo);
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testCanDisplayListOfCurrentMessages()
     {
         $displayInfoAssertion = '';
@@ -379,7 +397,7 @@ class FlashMessengerTest extends TestCase
 
     public function testCanTranslateMessages()
     {
-        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator = $this->getMockBuilder('Zend\I18n\Translator\Translator')->getMock();
         $mockTranslator->expects($this->exactly(1))
         ->method('translate')
         ->will($this->returnValue('translated message'));
@@ -396,7 +414,7 @@ class FlashMessengerTest extends TestCase
 
     public function testCanTranslateCurrentMessages()
     {
-        $mockTranslator = $this->getMock('Zend\I18n\Translator\Translator');
+        $mockTranslator = $this->getMockBuilder('Zend\I18n\Translator\Translator')->getMock();
         $mockTranslator->expects($this->exactly(1))
         ->method('translate')
         ->will($this->returnValue('translated message'));

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -9,7 +9,8 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Renderer\PhpRenderer as View;
 use Zend\View\Helper\Gravatar;
 
@@ -127,7 +128,7 @@ class GravatarTest extends TestCase
     public function testInvalidRatingParametr()
     {
         $ratingsWrong = [ 'a', 'cs', 456];
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         foreach ($ratingsWrong as $value) {
             $this->helper->setRating($value);
         }

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -9,6 +9,8 @@
 
 namespace ZendTest\View\Helper;
 
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Helper;
 use Zend\View\Renderer\PhpRenderer as View;
 use Zend\View\Exception\ExceptionInterface as ViewException;
@@ -19,7 +21,7 @@ use Zend\View\Exception\ExceptionInterface as ViewException;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HeadLinkTest extends \PHPUnit_Framework_TestCase
+class HeadLinkTest extends TestCase
 {
     /**
      * @var Helper\HeadLink
@@ -65,25 +67,25 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
     public function testPrependThrowsExceptionWithoutArrayArgument()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->prepend('foo');
     }
 
     public function testAppendThrowsExceptionWithoutArrayArgument()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->append('foo');
     }
 
     public function testSetThrowsExceptionWithoutArrayArgument()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->set('foo');
     }
 
     public function testOffsetSetThrowsExceptionWithoutArrayArgument()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->offsetSet(1, 'foo');
     }
 
@@ -202,7 +204,7 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
     public function testOverloadingThrowsExceptionWithNoArguments()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->appendStylesheet();
     }
 
@@ -215,7 +217,7 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
     public function testOverloadingUsingSingleArrayArgumentWithInvalidValuesThrowsException()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->setStylesheet(['bogus' => 'unused']);
     }
 
@@ -230,7 +232,7 @@ class HeadLinkTest extends \PHPUnit_Framework_TestCase
 
     public function testOverloadingThrowsExceptionWithInvalidMethod()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->bogusMethod();
     }
 

--- a/test/Helper/HeadMetaTest.php
+++ b/test/Helper/HeadMetaTest.php
@@ -9,6 +9,8 @@
 
 namespace ZendTest\View\Helper;
 
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Renderer\PhpRenderer as View;
 use Zend\View\Helper;
 use Zend\View\Exception\ExceptionInterface as ViewException;
@@ -19,7 +21,7 @@ use Zend\View\Exception\ExceptionInterface as ViewException;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HeadMetaTest extends \PHPUnit_Framework_TestCase
+class HeadMetaTest extends TestCase
 {
     /**
      * @var Helper\HeadMeta
@@ -204,13 +206,13 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
 
     public function testOverloadingThrowsExceptionWithFewerThanTwoArgs()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->setName('foo');
     }
 
     public function testOverloadingThrowsExceptionWithInvalidMethodType()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->helper->setFoo('foo');
     }
 
@@ -396,7 +398,7 @@ class HeadMetaTest extends \PHPUnit_Framework_TestCase
         $view = new View();
         $view->plugin('doctype')->__invoke('HTML4_STRICT');
 
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $view->plugin('headMeta')->setCharset('utf-8');
     }
 

--- a/test/Helper/HeadScriptTest.php
+++ b/test/Helper/HeadScriptTest.php
@@ -18,7 +18,7 @@ use Zend\View;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HeadScriptTest extends \PHPUnit_Framework_TestCase
+class HeadScriptTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Helper\HeadScript

--- a/test/Helper/HeadStyleTest.php
+++ b/test/Helper/HeadStyleTest.php
@@ -18,7 +18,7 @@ use Zend\View;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HeadStyleTest extends \PHPUnit_Framework_TestCase
+class HeadStyleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Helper\HeadStyle

--- a/test/Helper/HeadTitleTest.php
+++ b/test/Helper/HeadTitleTest.php
@@ -18,7 +18,7 @@ use Zend\View\Helper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HeadTitleTest extends \PHPUnit_Framework_TestCase
+class HeadTitleTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Helper\HeadTitle
@@ -185,7 +185,7 @@ class HeadTitleTest extends \PHPUnit_Framework_TestCase
 
     public function testTranslatorMethods()
     {
-        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock = $this->getMockBuilder('Zend\I18n\Translator\Translator')->getMock();
         $this->helper->setTranslator($translatorMock, 'foo');
 
         $this->assertEquals($translatorMock, $this->helper->getTranslator());

--- a/test/Helper/HtmlFlashTest.php
+++ b/test/Helper/HtmlFlashTest.php
@@ -16,7 +16,7 @@ use Zend\View\Helper\HtmlFlash;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HtmlFlashTest extends \PHPUnit_Framework_TestCase
+class HtmlFlashTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var HtmlFlash

--- a/test/Helper/HtmlListTest.php
+++ b/test/Helper/HtmlListTest.php
@@ -9,6 +9,8 @@
 
 namespace ZendTest\View\Helper;
 
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Helper;
 use Zend\View\Renderer\PhpRenderer as View;
 
@@ -16,7 +18,7 @@ use Zend\View\Renderer\PhpRenderer as View;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HtmlListTest extends \PHPUnit_Framework_TestCase
+class HtmlListTest extends TestCase
 {
     /**
      * @var Helper\HtmlList
@@ -223,7 +225,7 @@ class HtmlListTest extends \PHPUnit_Framework_TestCase
      */
     public function testEmptyItems()
     {
-        $this->setExpectedException('Zend\View\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $this->helper->__invoke([]);
     }
 }

--- a/test/Helper/HtmlObjectTest.php
+++ b/test/Helper/HtmlObjectTest.php
@@ -17,7 +17,7 @@ use Zend\View\Helper\HtmlObject;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HtmlObjectTest extends \PHPUnit_Framework_TestCase
+class HtmlObjectTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var HtmlObject

--- a/test/Helper/HtmlPageTest.php
+++ b/test/Helper/HtmlPageTest.php
@@ -16,7 +16,7 @@ use Zend\View\Helper\HtmlPage;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HtmlPageTest extends \PHPUnit_Framework_TestCase
+class HtmlPageTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var HtmlPage

--- a/test/Helper/HtmlQuicktimeTest.php
+++ b/test/Helper/HtmlQuicktimeTest.php
@@ -16,7 +16,7 @@ use Zend\View\Helper\HtmlQuicktime;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HtmlQuicktimeTest extends \PHPUnit_Framework_TestCase
+class HtmlQuicktimeTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var HtmlQuicktime

--- a/test/Helper/HtmlTagTest.php
+++ b/test/Helper/HtmlTagTest.php
@@ -16,7 +16,7 @@ use Zend\View\Helper\HtmlTag;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class HtmlTagTest extends \PHPUnit_Framework_TestCase
+class HtmlTagTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var HtmlTag

--- a/test/Helper/IdentityTest.php
+++ b/test/Helper/IdentityTest.php
@@ -21,7 +21,7 @@ use Zend\View\Helper\Identity as IdentityHelper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class IdentityTest extends \PHPUnit_Framework_TestCase
+class IdentityTest extends \PHPUnit\Framework\TestCase
 {
     public function testGetIdentity()
     {

--- a/test/Helper/InlineScriptTest.php
+++ b/test/Helper/InlineScriptTest.php
@@ -17,7 +17,7 @@ use Zend\View\Helper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class InlineScriptTest extends \PHPUnit_Framework_TestCase
+class InlineScriptTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Helper\InlineScript

--- a/test/Helper/JsonTest.php
+++ b/test/Helper/JsonTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Http\Response;
 use Zend\Json\Json as JsonFormatter;
 use Zend\View\Helper\Json as JsonHelper;

--- a/test/Helper/LayoutTest.php
+++ b/test/Helper/LayoutTest.php
@@ -9,6 +9,8 @@
 
 namespace ZendTest\View\Helper;
 
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Helper\Layout;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer;
@@ -19,7 +21,7 @@ use Zend\View\Renderer\PhpRenderer;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class LayoutTest extends \PHPUnit_Framework_TestCase
+class LayoutTest extends TestCase
 {
     /**
      * Sets up the fixture, for example, open a network connection.
@@ -69,7 +71,8 @@ class LayoutTest extends \PHPUnit_Framework_TestCase
         $viewModelHelper = $renderer->plugin('view_model');
         $helper          = $renderer->plugin('layout');
 
-        $this->setExpectedException('Zend\View\Exception\RuntimeException', 'view model');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('view model');
         $helper->setTemplate('foo/bar');
     }
 }

--- a/test/Helper/Navigation/AbstractTest.php
+++ b/test/Helper/Navigation/AbstractTest.php
@@ -27,7 +27,7 @@ use ZendTest\View\Helper\TestAsset;
 /**
  * Base class for navigation view helper tests
  */
-abstract class AbstractTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var

--- a/test/Helper/Navigation/NavigationTest.php
+++ b/test/Helper/Navigation/NavigationTest.php
@@ -219,7 +219,7 @@ class NavigationTest extends AbstractTest
 
     public function testTranslatorMethods()
     {
-        $translatorMock = $this->getMock('Zend\I18n\Translator\Translator');
+        $translatorMock = $this->getMockBuilder('Zend\I18n\Translator\Translator')->getMock();
         $this->_helper->setTranslator($translatorMock, 'foo');
 
         $this->assertEquals($translatorMock, $this->_helper->getTranslator());

--- a/test/Helper/Navigation/PluginManagerCompatibilityTest.php
+++ b/test/Helper/Navigation/PluginManagerCompatibilityTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\View\Helper\Navigation;
 
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\Config;
 use Zend\ServiceManager\ServiceManager;
 use Zend\ServiceManager\Test\CommonPluginManagerTrait;
@@ -20,7 +21,7 @@ use Zend\View\Helper\Navigation\PluginManager;
 /**
  * @group      Zend_View
  */
-class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
+class PluginManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
@@ -85,22 +86,22 @@ class PluginManagerCompatibilityTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     * @todo remove this test once we set the minimum zend-servicemanager version to 3
      */
     public function testRegisteringInvalidElementRaisesException()
     {
-        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->expectException($this->getServiceNotFoundException());
         $this->getPluginManager()->setService('test', $this);
     }
 
     /**
-     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     * @todo remove this test once we set the minimum zend-servicemanager version to 3
      */
     public function testLoadingInvalidElementRaisesException()
     {
         $manager = $this->getPluginManager();
         $manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->expectException($this->getServiceNotFoundException());
         $manager->get('test');
     }
 }

--- a/test/Helper/PaginationControlTest.php
+++ b/test/Helper/PaginationControlTest.php
@@ -9,7 +9,9 @@
 
 namespace ZendTest\View\Helper;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Paginator;
+use Zend\View\Exception;
 use Zend\View\Helper;
 use Zend\View\Renderer\PhpRenderer as View;
 use Zend\View\Resolver;
@@ -18,7 +20,7 @@ use Zend\View\Resolver;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class PaginationControlTest extends \PHPUnit_Framework_TestCase
+class PaginationControlTest extends TestCase
 {
     // @codingStandardsIgnoreStart
     /**
@@ -131,10 +133,8 @@ class PaginationControlTest extends \PHPUnit_Framework_TestCase
     {
         Helper\PaginationControl::setDefaultViewPartial('testPagination.phtml');
 
-        $this->setExpectedException(
-            'Zend\View\Exception\ExceptionInterface',
-            'No paginator instance provided or incorrect type'
-        );
+        $this->expectException(Exception\ExceptionInterface::class);
+        $this->expectExceptionMessage('No paginator instance provided or incorrect type');
         $this->_viewHelper->__invoke();
     }
 

--- a/test/Helper/PartialLoopTest.php
+++ b/test/Helper/PartialLoopTest.php
@@ -11,7 +11,8 @@ namespace ZendTest\View\Helper;
 
 use ArrayObject;
 use stdClass;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Helper\PartialLoop;
 use Zend\View\Renderer\PhpRenderer as View;
 
@@ -146,7 +147,7 @@ class PartialLoopTest extends TestCase
         $view->resolver()->addPath($this->basePath . '/application/views/scripts');
         $this->helper->setView($view);
 
-        $this->setExpectedException('Zend\View\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $result = $this->helper->__invoke('partialLoop.phtml', null);
     }
 
@@ -359,20 +360,16 @@ class PartialLoopTest extends TestCase
 
     public function testPartialLoopWithInvalidValuesWillRaiseException()
     {
-        $this->setExpectedException(
-            'Zend\View\Exception\InvalidArgumentException',
-            'PartialLoop helper requires iterable data, string given'
-        );
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('PartialLoop helper requires iterable data, string given');
 
         $this->helper->__invoke('partialLoopParentObject.phtml', 'foo');
     }
 
     public function testPartialLoopWithInvalidObjectValuesWillRaiseException()
     {
-        $this->setExpectedException(
-            'Zend\View\Exception\InvalidArgumentException',
-            'PartialLoop helper requires iterable data, stdClass given'
-        );
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('PartialLoop helper requires iterable data, stdClass given');
 
         $this->helper->__invoke('partialLoopParentObject.phtml', new stdClass());
     }
@@ -467,7 +464,7 @@ class PartialLoopTest extends TestCase
         $view->resolver()->addPath($this->basePath . '/application/views/scripts');
         $this->helper->setView($view);
 
-        $this->setExpectedException('Zend\View\Exception\InvalidArgumentException');
+        $this->expectException(Exception\InvalidArgumentException::class);
         $result = $this->helper->loop('partialLoop.phtml', null);
     }
 
@@ -674,20 +671,16 @@ class PartialLoopTest extends TestCase
 
     public function testPartialLoopWithInvalidValuesWillRaiseExceptionInLoopMethod()
     {
-        $this->setExpectedException(
-            'Zend\View\Exception\InvalidArgumentException',
-            'PartialLoop helper requires iterable data, string given'
-        );
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('PartialLoop helper requires iterable data, string given');
 
         $this->helper->loop('partialLoopParentObject.phtml', 'foo');
     }
 
     public function testPartialLoopWithInvalidObjectValuesWillRaiseExceptionInLoopMethod()
     {
-        $this->setExpectedException(
-            'Zend\View\Exception\InvalidArgumentException',
-            'PartialLoop helper requires iterable data, stdClass given'
-        );
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('PartialLoop helper requires iterable data, stdClass given');
 
         $this->helper->loop('partialLoopParentObject.phtml', new stdClass());
     }

--- a/test/Helper/PartialTest.php
+++ b/test/Helper/PartialTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\View\Helper\Partial;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer as View;

--- a/test/Helper/Placeholder/ContainerTest.php
+++ b/test/Helper/Placeholder/ContainerTest.php
@@ -15,7 +15,7 @@ namespace ZendTest\View\Helper\Placeholder;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class ContainerTest extends \PHPUnit_Framework_TestCase
+class ContainerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Zend\View\Helper\Placeholder\Container

--- a/test/Helper/Placeholder/RegistryTest.php
+++ b/test/Helper/Placeholder/RegistryTest.php
@@ -18,7 +18,7 @@ use Zend\View\Helper\Placeholder\Container;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class RegistryTest extends \PHPUnit_Framework_TestCase
+class RegistryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Registry

--- a/test/Helper/Placeholder/StandaloneContainerTest.php
+++ b/test/Helper/Placeholder/StandaloneContainerTest.php
@@ -19,7 +19,7 @@ use ZendTest\View\Helper\TestAsset\Foo;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class StandaloneContainerTest extends \PHPUnit_Framework_TestCase
+class StandaloneContainerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Foo

--- a/test/Helper/PlaceholderTest.php
+++ b/test/Helper/PlaceholderTest.php
@@ -18,7 +18,7 @@ use Zend\View\Helper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class PlaceholderTest extends \PHPUnit_Framework_TestCase
+class PlaceholderTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Helper\Placeholder

--- a/test/Helper/RenderChildModelTest.php
+++ b/test/Helper/RenderChildModelTest.php
@@ -9,7 +9,8 @@
 
 namespace ZendTest\View\Helper;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\PhpRenderer;
 use Zend\View\Resolver\TemplateMapResolver;
@@ -125,7 +126,8 @@ class RenderChildModelTest extends TestCase
     {
         $renderer = new PhpRenderer();
         $renderer->setResolver($this->resolver);
-        $this->setExpectedException('Zend\View\Exception\RuntimeException', 'no view model');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('no view model');
         $renderer->render('layout');
     }
 }

--- a/test/Helper/RenderToPlaceholderTest.php
+++ b/test/Helper/RenderToPlaceholderTest.php
@@ -15,7 +15,7 @@ use Zend\View\Renderer\PhpRenderer as View;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class RenderToPlaceholderTest extends \PHPUnit_Framework_TestCase
+class RenderToPlaceholderTest extends \PHPUnit\Framework\TestCase
 {
     // @codingStandardsIgnoreStart
     protected $_view = null;

--- a/test/Helper/ServerUrlTest.php
+++ b/test/Helper/ServerUrlTest.php
@@ -17,7 +17,7 @@ use Zend\View\Helper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class ServerUrlTest extends \PHPUnit_Framework_TestCase
+class ServerUrlTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Back up of $_SERVER

--- a/test/Helper/UrlIntegrationTest.php
+++ b/test/Helper/UrlIntegrationTest.php
@@ -25,7 +25,7 @@ use Zend\ServiceManager\Config;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class UrlIntegrationTest extends \PHPUnit_Framework_TestCase
+class UrlIntegrationTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/test/Helper/UrlTest.php
+++ b/test/Helper/UrlTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\View\Helper;
 
+use PHPUnit\Framework\TestCase;
 use Zend\Mvc\MvcEvent;
 use Zend\Mvc\ModuleRouteListener;
 use Zend\Mvc\Router\Http\Literal as LiteralRoute;
@@ -34,7 +35,7 @@ use Zend\View\Helper\Url as UrlHelper;
  * @group      Zend_View
  * @group      Zend_View_Helper
  */
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends TestCase
 {
     /**
      * @var Router
@@ -97,7 +98,8 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     public function testHelperHasHardDependencyWithRouter()
     {
-        $this->setExpectedException(Exception\RuntimeException::class, 'No RouteStackInterface instance provided');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('No RouteStackInterface instance provided');
         $url = new UrlHelper;
         $url('home');
     }
@@ -132,14 +134,16 @@ class UrlTest extends \PHPUnit_Framework_TestCase
 
     public function testPluginWithoutRouteMatchesInEventRaisesExceptionWhenNoRouteProvided()
     {
-        $this->setExpectedException(Exception\RuntimeException::class, 'RouteMatch');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('RouteMatch');
         $this->url->__invoke();
     }
 
     public function testPluginWithRouteMatchesReturningNoMatchedRouteNameRaisesExceptionWhenNoRouteProvided()
     {
         $this->url->setRouteMatch(new $this->routeMatchType([]));
-        $this->setExpectedException(Exception\RuntimeException::class, 'matched');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('matched');
         $this->url->__invoke();
     }
 

--- a/test/HelperPluginManagerCompatibilityTest.php
+++ b/test/HelperPluginManagerCompatibilityTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use ReflectionProperty;
 use Zend\Mvc\Controller\Plugin\FlashMessenger as V2FlashMessenger;
 use Zend\Mvc\Controller\PluginManager as ControllerPluginManager;
@@ -91,22 +91,22 @@ class HelperPluginManagerCompatibilityTest extends TestCase
     }
 
     /**
-     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     * @todo remove this test once we set the minimum zend-servicemanager version to 3
      */
     public function testRegisteringInvalidElementRaisesException()
     {
-        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->expectException($this->getServiceNotFoundException());
         $this->getPluginManager()->setService('test', $this);
     }
 
     /**
-     * @todo Remove when package has upgraded to PHPUnit 5.7/6.0 series.
+     * @todo remove this test once we set the minimum zend-servicemanager version to 3
      */
     public function testLoadingInvalidElementRaisesException()
     {
         $manager = $this->getPluginManager();
         $manager->setInvokableClass('test', get_class($this));
-        $this->setExpectedException($this->getServiceNotFoundException());
+        $this->expectException($this->getServiceNotFoundException());
         $manager->get('test');
     }
 }

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -9,6 +9,7 @@
 
 namespace ZendTest\View;
 
+use PHPUnit\Framework\TestCase;
 use Zend\I18n\Translator\Translator;
 use Zend\Mvc\I18n\Translator as MvcTranslator;
 use Zend\ServiceManager\Config;
@@ -24,7 +25,7 @@ use Zend\View\Renderer\PhpRenderer;
 /**
  * @group      Zend_View
  */
-class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
+class HelperPluginManagerTest extends TestCase
 {
     public function setUp()
     {
@@ -90,7 +91,7 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
                 return $this;
             },
         ]]);
-        $this->setExpectedException($this->getServiceNotFoundException($helpers));
+        $this->expectException($this->getServiceNotFoundException($helpers));
         $helpers->get('test');
     }
 
@@ -99,7 +100,7 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
         $helpers = new HelperPluginManager(new ServiceManager(), ['invokables' => [
             'test' => get_class($this),
         ]]);
-        $this->setExpectedException($this->getServiceNotFoundException($helpers));
+        $this->expectException($this->getServiceNotFoundException($helpers));
         $helpers->get('test');
     }
 
@@ -123,7 +124,9 @@ class HelperPluginManagerTest extends \PHPUnit_Framework_TestCase
 
     public function testIfHelperIsTranslatorAwareAndMvcTranslatorIsAvailableItWillInjectTheMvcTranslator()
     {
-        $translator = new MvcTranslator($this->getMock('Zend\I18n\Translator\TranslatorInterface'));
+        $translator = new MvcTranslator(
+            $this->getMockBuilder('Zend\I18n\Translator\TranslatorInterface')->getMock()
+        );
         $config = new Config(['services' => [
             'MvcTranslator' => $translator,
         ]]);

--- a/test/Model/JsonModelTest.php
+++ b/test/Model/JsonModelTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Model;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\View\Model\JsonModel;
 use Zend\Json\Json;
 

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -11,7 +11,8 @@ namespace ZendTest\View\Model;
 
 use ArrayObject;
 use stdClass;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Model\ViewModel;
 use Zend\View\Variables as ViewVariables;
 use ZendTest\View\Model\TestAsset\Variable;
@@ -148,14 +149,16 @@ class ViewModelTest extends TestCase
     public function testPassingAnInvalidArgumentToSetVariablesRaisesAnException()
     {
         $model = new ViewModel();
-        $this->setExpectedException('Zend\View\Exception\InvalidArgumentException', 'expects an array');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects an array');
         $model->setVariables(new stdClass);
     }
 
     public function testPassingAnInvalidArgumentToSetOptionsRaisesAnException()
     {
         $model = new ViewModel();
-        $this->setExpectedException('Zend\View\Exception\InvalidArgumentException', 'expects an array');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects an array');
         $model->setOptions(new stdClass);
     }
 

--- a/test/PhpRendererTest.php
+++ b/test/PhpRendererTest.php
@@ -9,7 +9,9 @@
 
 namespace ZendTest\View;
 
+use PHPUnit\Framework\TestCase;
 use Zend\ServiceManager\ServiceManager;
+use Zend\View\Exception;
 use Zend\View\HelperPluginManager;
 use Zend\View\Renderer\PhpRenderer;
 use Zend\View\Model\ViewModel;
@@ -21,7 +23,7 @@ use Zend\Filter\FilterChain;
 /**
  * @group      Zend_View
  */
-class PhpRendererTest extends \PHPUnit_Framework_TestCase
+class PhpRendererTest extends TestCase
 {
     public function setUp()
     {
@@ -90,7 +92,8 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
 
     public function testPassingStringOfUndefinedClassToSetHelperPluginManagerRaisesException()
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface', 'Invalid');
+        $this->expectException(Exception\ExceptionInterface::class);
+        $this->expectExceptionMessage('Invalid');
         $this->renderer->setHelperPluginManager('__foo__');
     }
 
@@ -116,7 +119,8 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
      */
     public function testPassingInvalidArgumentToSetHelperPluginManagerRaisesException($plugins)
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface', 'must extend');
+        $this->expectException(Exception\ExceptionInterface::class);
+        $this->expectExceptionMessage('must extend');
         $this->renderer->setHelperPluginManager($plugins);
     }
 
@@ -291,7 +295,7 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
     public function testViewModelWithoutTemplateRaisesException()
     {
         $model = new ViewModel();
-        $this->setExpectedException('Zend\View\Exception\DomainException');
+        $this->expectException(Exception\DomainException::class);
         $content = $this->renderer->render($model);
     }
 
@@ -354,7 +358,8 @@ class PhpRendererTest extends \PHPUnit_Framework_TestCase
     {
         $expected = '10 &gt; 9';
         $this->renderer->vars()->assign(['foo' => '10 > 9']);
-        $this->setExpectedException('Zend\View\Exception\RuntimeException', 'could not resolve');
+        $this->expectException(Exception\RuntimeException::class);
+        $this->expectExceptionMessage('could not resolve');
         $test = $this->renderer->render('should-not-find-this');
     }
 

--- a/test/Renderer/FeedRendererTest.php
+++ b/test/Renderer/FeedRendererTest.php
@@ -9,7 +9,8 @@
 
 namespace ZendTest\View\Renderer;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Model\FeedModel;
 use Zend\View\Model\ViewModel;
 use Zend\View\Renderer\FeedRenderer;
@@ -19,7 +20,6 @@ class FeedRendererTest extends TestCase
 {
     public function setUp()
     {
-        $this->markTestIncomplete('Re-enable tests after zend-feed has been updated to zend-servicemanager v3');
         $this->renderer = new FeedRenderer();
     }
 
@@ -110,16 +110,15 @@ class FeedRendererTest extends TestCase
 
     public function testNonStringNonModelArgumentRaisesException()
     {
-        $this->setExpectedException('Zend\View\Exception\InvalidArgumentException', 'expects');
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects');
         $this->renderer->render(['foo']);
     }
 
     public function testSettingUnacceptableFeedTypeRaisesException()
     {
-        $this->setExpectedException(
-            'Zend\View\Exception\InvalidArgumentException',
-            'expects a string of either "rss" or "atom"'
-        );
+        $this->expectException(Exception\InvalidArgumentException::class);
+        $this->expectExceptionMessage('expects a string of either "rss" or "atom"');
         $this->renderer->setFeedType('foobar');
     }
 

--- a/test/Renderer/JsonRendererTest.php
+++ b/test/Renderer/JsonRendererTest.php
@@ -10,11 +10,12 @@
 namespace ZendTest\View\Renderer;
 
 use ArrayObject;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
-use Zend\View\Renderer\JsonRenderer;
+use Zend\View\Exception;
 use Zend\View\Model\JsonModel;
 use Zend\View\Model\ViewModel;
+use Zend\View\Renderer\JsonRenderer;
 
 /**
  * @group      Zend_View
@@ -158,7 +159,7 @@ class JsonRendererTest extends TestCase
 
     public function testNonViewModelInitialArgumentWithValuesRaisesException()
     {
-        $this->setExpectedException('Zend\View\Exception\DomainException');
+        $this->expectException(Exception\DomainException::class);
         $this->renderer->render('foo', ['bar' => 'baz']);
     }
 

--- a/test/Resolver/AggregateResolverTest.php
+++ b/test/Resolver/AggregateResolverTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Resolver;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\View\Resolver;
 
 class AggregateResolverTest extends TestCase

--- a/test/Resolver/PrefixPathStackResolverTest.php
+++ b/test/Resolver/PrefixPathStackResolverTest.php
@@ -16,7 +16,7 @@ use Zend\View\Resolver\PrefixPathStackResolver;
  *
  * @covers \Zend\View\Resolver\PrefixPathStackResolver
  */
-class PrefixPathStackResolverTest extends \PHPUnit_Framework_TestCase
+class PrefixPathStackResolverTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var string
@@ -67,7 +67,7 @@ class PrefixPathStackResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testSetCustomPathStackResolver()
     {
-        $mockResolver = $this->getMock('Zend\View\Resolver\ResolverInterface');
+        $mockResolver = $this->getMockBuilder('Zend\View\Resolver\ResolverInterface')->getMock();
 
         $resolver = new PrefixPathStackResolver([
             'foo' => $mockResolver,

--- a/test/Resolver/RelativeFallbackResolverTest.php
+++ b/test/Resolver/RelativeFallbackResolverTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Resolver;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\View\Helper\ViewModel as ViewModelHelper;
 use Zend\View\Model\ViewModel;
@@ -80,10 +80,10 @@ class RelativeFallbackResolverTest extends TestCase
     public function testSkipsResolutionOnViewRendererWithoutPlugins()
     {
         /* @var $baseResolver \Zend\View\Resolver\ResolverInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $baseResolver = $this->getMock('Zend\View\Resolver\ResolverInterface');
+        $baseResolver = $this->getMockBuilder('Zend\View\Resolver\ResolverInterface')->getMock();
         $fallback     = new RelativeFallbackResolver($baseResolver);
         /* @var $renderer \Zend\View\Renderer\RendererInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $renderer     = $this->getMock('Zend\View\Renderer\RendererInterface');
+        $renderer     = $this->getMockBuilder('Zend\View\Renderer\RendererInterface')->getMock();
 
         $baseResolver->expects($this->never())->method('resolve');
 
@@ -93,13 +93,12 @@ class RelativeFallbackResolverTest extends TestCase
     public function testSkipsResolutionOnViewRendererWithoutCorrectCurrentPlugin()
     {
         /* @var $baseResolver \Zend\View\Resolver\ResolverInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $baseResolver = $this->getMock('Zend\View\Resolver\ResolverInterface');
+        $baseResolver = $this->getMockBuilder('Zend\View\Resolver\ResolverInterface')->getMock();
         $fallback     = new RelativeFallbackResolver($baseResolver);
         /* @var $renderer \Zend\View\Renderer\RendererInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $renderer     = $this->getMock(
-            'Zend\View\Renderer\RendererInterface',
-            ['getEngine', 'setResolver', 'plugin', 'render']
-        );
+        $renderer     = $this->getMockBuilder('Zend\View\Renderer\RendererInterface')
+            ->setMethods(['getEngine', 'setResolver', 'plugin', 'render'])
+            ->getMock();
 
         $baseResolver->expects($this->never())->method('resolve');
         $renderer->expects($this->once())->method('plugin')->will($this->returnValue(new stdClass()));
@@ -110,14 +109,13 @@ class RelativeFallbackResolverTest extends TestCase
     public function testSkipsResolutionOnNonExistingCurrentViewModel()
     {
         /* @var $baseResolver \Zend\View\Resolver\ResolverInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $baseResolver = $this->getMock('Zend\View\Resolver\ResolverInterface');
+        $baseResolver = $this->getMockBuilder('Zend\View\Resolver\ResolverInterface')->getMock();
         $fallback     = new RelativeFallbackResolver($baseResolver);
         $viewModel    = new ViewModelHelper();
         /* @var $renderer \Zend\View\Renderer\RendererInterface|\PHPUnit_Framework_MockObject_MockObject */
-        $renderer     = $this->getMock(
-            'Zend\View\Renderer\RendererInterface',
-            ['getEngine', 'setResolver', 'plugin', 'render']
-        );
+        $renderer     = $this->getMockBuilder('Zend\View\Renderer\RendererInterface')
+            ->setMethods(['getEngine', 'setResolver', 'plugin', 'render'])
+            ->getMock();
 
         $baseResolver->expects($this->never())->method('resolve');
         $renderer->expects($this->once())->method('plugin')->will($this->returnValue($viewModel));

--- a/test/Resolver/TemplateMapResolverTest.php
+++ b/test/Resolver/TemplateMapResolverTest.php
@@ -10,7 +10,7 @@
 namespace ZendTest\View\Resolver;
 
 use ArrayObject;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\View\Resolver\TemplateMapResolver;
 
 class TemplateMapResolverTest extends TestCase

--- a/test/Resolver/TemplatePathStackTest.php
+++ b/test/Resolver/TemplatePathStackTest.php
@@ -9,12 +9,14 @@
 
 namespace ZendTest\View\Resolver;
 
+use PHPUnit\Framework\TestCase;
+use Zend\View\Exception;
 use Zend\View\Resolver\TemplatePathStack;
 
 /**
  * @group      Zend_View
  */
-class TemplatePathStackTest extends \PHPUnit_Framework_TestCase
+class TemplatePathStackTest extends TestCase
 {
     /**
      * @var TemplatePathStack
@@ -126,7 +128,8 @@ class TemplatePathStackTest extends \PHPUnit_Framework_TestCase
     {
         $this->stack->addPath($this->baseDir . '/_templates');
 
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface', 'parent directory traversal');
+        $this->expectException(Exception\ExceptionInterface::class);
+        $this->expectExceptionMessage('parent directory traversal');
         $this->stack->resolve('../_stubs/scripts/LfiProtectionCheck.phtml');
     }
 
@@ -191,7 +194,7 @@ class TemplatePathStackTest extends \PHPUnit_Framework_TestCase
      */
     public function testSettingOptionsWithInvalidArgumentRaisesException($options)
     {
-        $this->setExpectedException('Zend\View\Exception\ExceptionInterface');
+        $this->expectException(Exception\ExceptionInterface::class);
         $this->stack->setOptions($options);
     }
 

--- a/test/Strategy/FeedStrategyTest.php
+++ b/test/Strategy/FeedStrategyTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Strategy;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\Feed\Writer\FeedFactory;

--- a/test/Strategy/JsonStrategyTest.php
+++ b/test/Strategy/JsonStrategyTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Strategy;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\Http\Request as HttpRequest;

--- a/test/Strategy/PhpRendererStrategyTest.php
+++ b/test/Strategy/PhpRendererStrategyTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View\Strategy;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\EventManager\EventManager;
 use Zend\EventManager\Test\EventListenerIntrospectionTrait;
 use Zend\Http\Response as HttpResponse;

--- a/test/VariablesTest.php
+++ b/test/VariablesTest.php
@@ -15,7 +15,7 @@ use Zend\Config\Config;
 /**
  * @group      Zend_View
  */
-class VariablesTest extends \PHPUnit_Framework_TestCase
+class VariablesTest extends \PHPUnit\Framework\TestCase
 {
     public function setup()
     {

--- a/test/ViewEventTest.php
+++ b/test/ViewEventTest.php
@@ -9,7 +9,7 @@
 
 namespace ZendTest\View;
 
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use Zend\Http\Request;
 use Zend\Http\Response;
 use Zend\View\Model\ViewModel;

--- a/test/ViewTest.php
+++ b/test/ViewTest.php
@@ -10,10 +10,11 @@
 namespace ZendTest\View;
 
 use ArrayObject;
-use PHPUnit_Framework_TestCase as TestCase;
+use PHPUnit\Framework\TestCase;
 use stdClass;
 use Zend\Http\Request;
 use Zend\Http\Response;
+use Zend\View\Exception;
 use Zend\View\Model\ViewModel;
 use Zend\View\Model\JsonModel;
 use Zend\View\Renderer\PhpRenderer;
@@ -164,7 +165,7 @@ class ViewTest extends TestCase
         $this->model->setVariable('parent', 'node');
         $this->model->addChild($child1);
 
-        $this->setExpectedException('Zend\View\Exception\DomainException');
+        $this->expectException(Exception\DomainException::class);
         $this->view->render($this->model);
     }
 
@@ -314,7 +315,9 @@ class ViewTest extends TestCase
      */
     public function testModelFromEventIsUsedByRenderer()
     {
-        $renderer = $this->getMock('Zend\View\Renderer\PhpRenderer', ['render']);
+        $renderer = $this->getMockBuilder('Zend\View\Renderer\PhpRenderer')
+            ->setMethods(['render'])
+            ->getMock();
 
         $model1 = new ViewModel;
         $model2 = new ViewModel;


### PR DESCRIPTION
This patch updates the package to:

- Set the minimum supported PHP version to 5.6.
- Set the supported PHPUnit version to either 5.7 or 6.0, depending on PHP version used.

A number of test changes were required:

- All references to `PHPUnit_Framework_TestCase` were updated to the namespaced version. In any case where the class was not imported, an import statement was created.
- All `setExpectedException()` calls were updated to `expectException()`, and, if an expected message was provided, `expectExceptionMessage()`
- A number of `getMock()` calls still existed without usage of `getMockBuilder()`; these were updated.
- A zend-servicemanager test trait for testing container compatibility between zend-servicemanager versions differs from v2 to v3; the two instances in this particular suite were updated to override the necessary tests to vary strategy based on which PHP version was detected.
- New test failures were discovered in the flash messenger tests due to differences in how PHPUnit handles global state; these were corrected.