### PR TITLE
spelling fixes

### DIFF
--- a/test/Helper/DoctypeTest.php
+++ b/test/Helper/DoctypeTest.php
@@ -137,7 +137,7 @@ class DoctypeTest extends TestCase
 
     public function testIsRdfa()
     {
-        // ensure default registerd Doctype is false
+        // ensure default registered Doctype is false
         $this->assertFalse($this->helper->isRdfa());
 
         $this->assertTrue($this->helper->__invoke(Helper\Doctype::XHTML1_RDFA)->isRdfa());


### PR DESCRIPTION
patch contains some spelling fixes ( just in comments ) as found by a bot ( http://www.misfix.org, https://github.com/ka7/misspell_fixer ). Any upcoming License changes (e.g. GPL2 to GPL3+) are hereby granted.