### PR TITLE
Return early on HelperPluginManager::injectTranslator() when helper has translator already

### DIFF
--- a/src/HelperPluginManager.php
+++ b/src/HelperPluginManager.php
@@ -337,6 +337,10 @@ class HelperPluginManager extends AbstractPluginManager
             return;
         }
 
+        if (method_exists($helper, 'hasTranslator') && $helper->hasTranslator()) {
+            return;
+        }
+
         if ($container->has('MvcTranslator')) {
             $helper->setTranslator($container->get('MvcTranslator'));
             return;

--- a/test/HelperPluginManagerTest.php
+++ b/test/HelperPluginManagerTest.php
@@ -186,6 +186,28 @@ class HelperPluginManagerTest extends TestCase
         $this->assertNull($helper->getTranslator());
     }
 
+    public function testInjectTranslatorWillReturnEarlyIfTheHelperHasTranslatorAlready()
+    {
+        $translatorA = new Translator();
+        $translatorB = new Translator();
+        $config = new Config(['services' => [
+            'Translator' => $translatorB,
+        ]]);
+        $services = new ServiceManager();
+        $config->configureServiceManager($services);
+        $helpers = new HelperPluginManager($services);
+        $helpers->setFactory(
+            'TestHelper',
+            function () use ($translatorA) {
+                $helper = new HeadTitle();
+                $helper->setTranslator($translatorA);
+                return $helper;
+            }
+        );
+        $helperB = $helpers->get('TestHelper');
+        $this->assertSame($translatorA, $helperB->getTranslator());
+    }
+
     public function testCanOverrideAFactoryViaConfigurationPassedToConstructor()
     {
         $helper  = $this->prophesize(HelperInterface::class)->reveal();


### PR DESCRIPTION
When creating helper via factory with injected translator the HelperPluginManager overrides this translator with the default one, so check is added to prevent this.