### PR TITLE
PHP 7 - Php Renderer - Catching Error - Bug fix

### DIFF
--- a/src/Renderer/PhpRenderer.php
+++ b/src/Renderer/PhpRenderer.php
@@ -504,7 +504,10 @@ class PhpRenderer implements Renderer, TreeRendererInterface
                 ob_start();
                 $includeReturn = include $this->__file;
                 $this->__content = ob_get_clean();
-            } catch (\Exception $ex) {
+            } catch (\Throwable $ex) {
+                ob_end_clean();
+                throw $ex;
+            } catch (\Exception $ex) { // @TODO clean up once PHP 7 requirement is enforced
                 ob_end_clean();
                 throw $ex;
             }


### PR DESCRIPTION
The php renderer was only catching Exception - PHP 7 changed how error are reported 
http://php.net/manual/en/language.errors.php7.php