### PR TITLE
Allow to use ‘as’ attribute on HTML ‘link’ element

### DIFF
--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -51,7 +51,8 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         'extras',
         'itemprop',
         'crossorigin',
-        'integrity'
+        'integrity',
+        'as'
     ];
 
     /**

--- a/src/Helper/HeadLink.php
+++ b/src/Helper/HeadLink.php
@@ -52,7 +52,7 @@ class HeadLink extends Placeholder\Container\AbstractStandalone
         'itemprop',
         'crossorigin',
         'integrity',
-        'as'
+        'as',
     ];
 
     /**

--- a/test/Helper/HeadLinkTest.php
+++ b/test/Helper/HeadLinkTest.php
@@ -457,4 +457,10 @@ class HeadLinkTest extends TestCase
         $this->helper->prependAlternate(['itemprop' => 'url', 'href' => '/bar/baz', 'rel' => 'canonical']);
         $this->assertContains('itemprop="url"', $this->helper->toString());
     }
+
+    public function testAsAttributeIsSupported()
+    {
+        $this->helper->headLink(['as' => 'style', 'href' => '/foo/bar.css', 'rel' => 'preload']);
+        $this->assertContains('as="style"', $this->helper->toString());
+    }
 }


### PR DESCRIPTION
This patch allows to use the `as` attribute by the [`HeadLink` helper](https://github.com/zendframework/zend-view/blob/master/src/Helper/HeadLink.php).

Citing from [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Preloading_content):

> Using `as` to specify the type of content to be preloaded allows the browser to:
>
> * Prioritize resource loading more accurately.
> * Match future requests, reusing the same resource if appropriate.
> * Apply the correct [content security policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) to the resource.
> * Set the correct [`Accept`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept) request headers for it.
