### PR TITLE
Deprecate Attribs and Proxy to Attributes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -70,6 +70,9 @@
         }
     },
     "autoload-dev": {
+        "files": [
+            "test/autoload.php"
+        ],
         "psr-4": {
             "ZendTest\\View\\": "test/"
         }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
 
     <php>
         <ini name="date.timezone" value="UTC"/>
+        <ini name="max_execution_time" value="360"/>
 
         <!-- OB_ENABLED should be enabled for some tests to check if all
              functionality works as expected. Such tests include those for

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -23,6 +23,7 @@
 
     <php>
         <ini name="date.timezone" value="UTC"/>
+        <ini name="error_reporting" value="E_ALL"/>
         <ini name="max_execution_time" value="360"/>
 
         <!-- OB_ENABLED should be enabled for some tests to check if all

--- a/src/Helper/Gravatar.php
+++ b/src/Helper/Gravatar.php
@@ -183,6 +183,8 @@ class Gravatar extends AbstractHtmlElement
      *
      * @param  array $attribs
      * @return Gravatar
+     *
+     * @deprecated Please use Zend\View\Helper\Gravatar::setAttributes
      */
     public function setAttribs(array $attribs)
     {

--- a/src/Helper/Gravatar.php
+++ b/src/Helper/Gravatar.php
@@ -234,6 +234,8 @@ class Gravatar extends AbstractHtmlElement
      * value!
      *
      * @return array
+     *
+     * @deprecated Please use Zend\View\Helper\Gravatar::getAttributes
      */
     public function getAttribs()
     {

--- a/src/Helper/Gravatar.php
+++ b/src/Helper/Gravatar.php
@@ -186,6 +186,12 @@ class Gravatar extends AbstractHtmlElement
      */
     public function setAttribs(array $attribs)
     {
+        trigger_error(sprintf(
+            '%s is deprecated; please use %s::setAttributes',
+            __METHOD__,
+            __CLASS__
+        ), E_USER_DEPRECATED);
+
         $this->attribs = $attribs;
         return $this;
     }

--- a/src/Helper/Gravatar.php
+++ b/src/Helper/Gravatar.php
@@ -47,7 +47,7 @@ class Gravatar extends AbstractHtmlElement
      *
      * @var array
      */
-    protected $attribs;
+    protected $attributes;
 
     /**
      * Email Address
@@ -86,12 +86,12 @@ class Gravatar extends AbstractHtmlElement
      *
      * @see    http://pl.gravatar.com/site/implement/url
      * @see    http://pl.gravatar.com/site/implement/url More information about gravatar's service.
-     * @param  string|null $email   Email address.
-     * @param  null|array  $options Options
-     * @param  array       $attribs Attributes for image tag (title, alt etc.)
+     * @param  string|null $email      Email address.
+     * @param  null|array  $options    Options
+     * @param  array       $attributes Attributes for image tag (title, alt etc.)
      * @return Gravatar
      */
-    public function __invoke($email = "", $options = [], $attribs = [])
+    public function __invoke($email = "", $options = [], $attributes = [])
     {
         if (! empty($email)) {
             $this->setEmail($email);
@@ -99,8 +99,8 @@ class Gravatar extends AbstractHtmlElement
         if (! empty($options)) {
             $this->setOptions($options);
         }
-        if (! empty($attribs)) {
-            $this->setAttributes($attribs);
+        if (! empty($attributes)) {
+            $this->setAttributes($attributes);
         }
 
         return $this;
@@ -186,7 +186,7 @@ class Gravatar extends AbstractHtmlElement
      */
     public function setAttributes(array $attributes)
     {
-        $this->attribs = $attributes;
+        $this->attributes = $attributes;
         return $this;
     }
 
@@ -222,7 +222,7 @@ class Gravatar extends AbstractHtmlElement
      */
     public function getAttributes()
     {
-        return $this->attribs;
+        return $this->attributes;
     }
 
     /**
@@ -395,8 +395,8 @@ class Gravatar extends AbstractHtmlElement
      */
     protected function setSrcAttribForImg()
     {
-        $attribs        = $this->getAttributes();
-        $attribs['src'] = $this->getAvatarUrl();
-        $this->setAttributes($attribs);
+        $attributes        = $this->getAttributes();
+        $attributes['src'] = $this->getAvatarUrl();
+        $this->setAttributes($attributes);
     }
 }

--- a/src/Helper/Gravatar.php
+++ b/src/Helper/Gravatar.php
@@ -211,6 +211,21 @@ class Gravatar extends AbstractHtmlElement
     }
 
     /**
+     * Get attributes of image
+     *
+     * Warning!
+     * If you set src attribute, you get it, but this value will be overwritten in
+     * protected method setSrcAttribForImg(). And finally your get other src
+     * value!
+     *
+     * @return array
+     */
+    public function getAttributes()
+    {
+        return $this->attribs;
+    }
+
+    /**
      * Get attribs of image
      *
      * Warning!
@@ -222,6 +237,12 @@ class Gravatar extends AbstractHtmlElement
      */
     public function getAttribs()
     {
+        trigger_error(sprintf(
+            '%s is deprecated; please use %s::getAttributes',
+            __METHOD__,
+            __CLASS__
+        ), E_USER_DEPRECATED);
+
         return $this->attribs;
     }
 

--- a/src/Helper/Gravatar.php
+++ b/src/Helper/Gravatar.php
@@ -168,7 +168,7 @@ class Gravatar extends AbstractHtmlElement
     {
         $this->setSrcAttribForImg();
         $html = '<img'
-            . $this->htmlAttribs($this->getAttribs())
+            . $this->htmlAttribs($this->getAttributes())
             . $this->getClosingBracket();
 
         return $html;
@@ -245,7 +245,7 @@ class Gravatar extends AbstractHtmlElement
             __CLASS__
         ), E_USER_DEPRECATED);
 
-        return $this->attribs;
+        return $this->getAttributes();
     }
 
     /**
@@ -395,7 +395,7 @@ class Gravatar extends AbstractHtmlElement
      */
     protected function setSrcAttribForImg()
     {
-        $attribs        = $this->getAttribs();
+        $attribs        = $this->getAttributes();
         $attribs['src'] = $this->getAvatarUrl();
         $this->setAttributes($attribs);
     }

--- a/src/Helper/Gravatar.php
+++ b/src/Helper/Gravatar.php
@@ -100,7 +100,7 @@ class Gravatar extends AbstractHtmlElement
             $this->setOptions($options);
         }
         if (! empty($attribs)) {
-            $this->setAttribs($attribs);
+            $this->setAttributes($attribs);
         }
 
         return $this;
@@ -175,11 +175,23 @@ class Gravatar extends AbstractHtmlElement
     }
 
     /**
-     * Set attribs for image tag
+     * Set attributes for image tag
      *
-     * Warning! You shouldn't set src attrib for image tag.
-     * This attrib is overwritten in protected method setSrcAttribForImg().
+     * Warning! You shouldn't set src attribute for image tag.
+     * This attribute is overwritten in protected method setSrcAttribForImg().
      * This method(_setSrcAttribForImg) is called in public method getImgTag().
+     *
+     * @param  array $attributes
+     * @return Gravatar
+     */
+    public function setAttributes(array $attributes)
+    {
+        $this->attribs = $attributes;
+        return $this;
+    }
+
+    /**
+     * Set attribs for image tag
      *
      * @param  array $attribs
      * @return Gravatar
@@ -194,7 +206,7 @@ class Gravatar extends AbstractHtmlElement
             __CLASS__
         ), E_USER_DEPRECATED);
 
-        $this->attribs = $attribs;
+        $this->setAttributes($attribs);
         return $this;
     }
 
@@ -362,6 +374,6 @@ class Gravatar extends AbstractHtmlElement
     {
         $attribs        = $this->getAttribs();
         $attribs['src'] = $this->getAvatarUrl();
-        $this->setAttribs($attribs);
+        $this->setAttributes($attribs);
     }
 }

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -9,10 +9,11 @@
 
 namespace ZendTest\View\Helper;
 
+use PHPUnit\Framework\Error\Deprecated as DeprecatedError;
 use PHPUnit\Framework\TestCase;
 use Zend\View\Exception;
-use Zend\View\Renderer\PhpRenderer as View;
 use Zend\View\Helper\Gravatar;
+use Zend\View\Renderer\PhpRenderer as View;
 
 /**
  * @group      Zendview
@@ -284,5 +285,12 @@ class GravatarTest extends TestCase
             'example@example.com',
             $this->helper->__invoke('Example@Example.com ')->getEmail()
         );
+    }
+
+    public function testSetAttribsIsDeprecated()
+    {
+        $this->expectException(DeprecatedError::class);
+
+        $this->helper->setAttribs([]);
     }
 }

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -92,7 +92,7 @@ class GravatarTest extends TestCase
                      ->setImgSize(150)
                      ->setSecure(true)
                      ->setEmail("example@example.com")
-                     ->setAttribs($attribs)
+                     ->setAttributes($attribs)
                      ->setRating('pg');
         $this->assertEquals("monsterid", $this->helper->getDefaultImg());
         $this->assertEquals("pg", $this->helper->getRating());
@@ -239,7 +239,7 @@ class GravatarTest extends TestCase
     {
         $email = 'example@example.com';
         $this->helper->setEmail($email);
-        $this->helper->setAttribs([
+        $this->helper->setAttributes([
             'class' => 'gravatar',
             'src'   => 'http://example.com',
             'id'    => 'gravatarID',

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -302,4 +302,11 @@ class GravatarTest extends TestCase
 
         $this->assertContains('@deprecated', $comment);
     }
+
+    public function testGetAttribsIsDeprecated()
+    {
+        $this->expectException(DeprecatedError::class);
+
+        $this->helper->getAttribs();
+    }
 }

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -87,17 +87,17 @@ class GravatarTest extends TestCase
      */
     public function testGetAndSetMethods()
     {
-        $attribs = ['class' => 'gravatar', 'title' => 'avatar', 'id' => 'gravatar-1'];
+        $attributes = ['class' => 'gravatar', 'title' => 'avatar', 'id' => 'gravatar-1'];
         $this->helper->setDefaultImg('monsterid')
                      ->setImgSize(150)
                      ->setSecure(true)
                      ->setEmail("example@example.com")
-                     ->setAttributes($attribs)
+                     ->setAttributes($attributes)
                      ->setRating('pg');
         $this->assertEquals("monsterid", $this->helper->getDefaultImg());
         $this->assertEquals("pg", $this->helper->getRating());
         $this->assertEquals("example@example.com", $this->helper->getEmail());
-        $this->assertEquals($attribs, $this->helper->getAttributes());
+        $this->assertEquals($attributes, $this->helper->getAttributes());
         $this->assertEquals(150, $this->helper->getImgSize());
         $this->assertTrue($this->helper->getSecure());
     }
@@ -166,9 +166,9 @@ class GravatarTest extends TestCase
     }
 
     /**
-     * Test HTML attribs
+     * Test HTML attributes
      */
-    public function testImgAttribs()
+    public function testImgAttributes()
     {
         $this->assertRegExp(
             '/class="gravatar" title="Gravatar"/',
@@ -235,7 +235,7 @@ class GravatarTest extends TestCase
         );
     }
 
-    public function testSetAttribsWithSrcKey()
+    public function testSetAttributesWithSrcKey()
     {
         $email = 'example@example.com';
         $this->helper->setEmail($email);

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -97,7 +97,7 @@ class GravatarTest extends TestCase
         $this->assertEquals("monsterid", $this->helper->getDefaultImg());
         $this->assertEquals("pg", $this->helper->getRating());
         $this->assertEquals("example@example.com", $this->helper->getEmail());
-        $this->assertEquals($attribs, $this->helper->getAttribs());
+        $this->assertEquals($attribs, $this->helper->getAttributes());
         $this->assertEquals(150, $this->helper->getImgSize());
         $this->assertTrue($this->helper->getSecure());
     }

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -309,4 +309,12 @@ class GravatarTest extends TestCase
 
         $this->helper->getAttribs();
     }
+
+    public function testGetAttribsDocCommentHasDeprecated()
+    {
+        $method  = new ReflectionMethod($this->helper, 'getAttribs');
+        $comment = $method->getDocComment();
+
+        $this->assertContains('@deprecated', $comment);
+    }
 }

--- a/test/Helper/GravatarTest.php
+++ b/test/Helper/GravatarTest.php
@@ -11,6 +11,7 @@ namespace ZendTest\View\Helper;
 
 use PHPUnit\Framework\Error\Deprecated as DeprecatedError;
 use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
 use Zend\View\Exception;
 use Zend\View\Helper\Gravatar;
 use Zend\View\Renderer\PhpRenderer as View;
@@ -292,5 +293,13 @@ class GravatarTest extends TestCase
         $this->expectException(DeprecatedError::class);
 
         $this->helper->setAttribs([]);
+    }
+
+    public function testSetAttribsDocCommentHasDeprecated()
+    {
+        $method  = new ReflectionMethod($this->helper, 'setAttribs');
+        $comment = $method->getDocComment();
+
+        $this->assertContains('@deprecated', $comment);
     }
 }

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -4,3 +4,8 @@
  * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
  * @license   https://github.com/zendframework/zend-view/blob/master/LICENSE.md New BSD License
  */
+
+if (class_exists(PHPUnit_Framework_Error_Deprecated::class)
+    && ! class_exists(PHPUnit\Framework\Error\Deprecated::class)) {
+    class_alias(PHPUnit_Framework_Error_Deprecated::class, PHPUnit\Framework\Error\Deprecated::class);
+}

--- a/test/autoload.php
+++ b/test/autoload.php
@@ -1,0 +1,6 @@
+<?php
+/**
+ * @see       https://github.com/zendframework/zend-view for the canonical source repository
+ * @copyright Copyright (c) 2017 Zend Technologies USA Inc. (http://www.zend.com)
+ * @license   https://github.com/zendframework/zend-view/blob/master/LICENSE.md New BSD License
+ */


### PR DESCRIPTION
Remove all references to `attribs`, translating to `attributes`. Public methods like `setAttribs` and `getAttribs` trigger an `E_USER_DEPRECATED` and proxy to `setAttributes` and `getAttributes` instead.

Fix #87 