### PR TITLE
Fluent Interface missing on ConsoleModel::setErrorLevel

### DIFF
--- a/src/Model/ConsoleModel.php
+++ b/src/Model/ConsoleModel.php
@@ -31,10 +31,12 @@ class ConsoleModel extends ViewModel
      * Set error level to return after the application ends.
      *
      * @param int $errorLevel
+     * @return $this
      */
     public function setErrorLevel($errorLevel)
     {
         $this->options['errorLevel'] = $errorLevel;
+        return $this;
     }
 
     /**

--- a/test/Model/ConsoleModelTest.php
+++ b/test/Model/ConsoleModelTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace ZendTest\View\Model;
+
+use PHPUnit\Framework\TestCase;
+use Zend\View\Model\ConsoleModel;
+
+class ConsoleModelTest extends TestCase
+{
+    public function testImplementsModelInterface()
+    {
+        $model = new ConsoleModel();
+        $this->assertInstanceOf('Zend\View\Model\ModelInterface', $model);
+    }
+
+    /**
+     * @group zend-view-152
+     * @see https://github.com/zendframework/zend-view/issues/152
+     */
+    public function testSetErrorLevelIsReturningThis()
+    {
+        $model = new ConsoleModel();
+        $actual = $model->setErrorLevel(0);
+        $this->assertSame($model, $actual);
+    }
+}


### PR DESCRIPTION
Hello,

contrary to almost all other setter methods on classes that implement the ModelInterface, ConsoleModel::setErrorLevel ist not returning itself when the method is called.
I would assume that it would return $this.

Best regards