### PR TITLE
Correct malformed git clone url in contributing guide.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ pull your work into the master repository. We recommend using
 3. Clone the canonical repository locally and enter it.
 
    ```console
-   $ git clone git://github.com:zendframework/zend-view.git
+   $ git clone git@github.com:zendframework/zend-view.git
    $ cd zend-view
    ```
 


### PR DESCRIPTION
This tripped me up on the way to contributing another documentation fix.