### PR TITLE
Fix example of registering json renderer in Module.php

### DIFF
--- a/doc/book/quick-start.md
+++ b/doc/book/quick-start.md
@@ -632,7 +632,7 @@ class Module
         $jsonStrategy = $locator->get('ViewJsonStrategy');
 
         // Attach strategy, which is a listener aggregate, at high priority
-        $view->getEventManager()->attach($jsonStrategy, 100);
+        $jsonStrategy->attach($view->getEventManager(), 100);
     }
 }
 ```


### PR DESCRIPTION
Fix as according to what is suggested in issue #108.

Note that I don't understand in the slightest why it works over what was originally there. In fact, some lines in this look all out redundant, and I wonder why the `registerJsonJStrategy` method doesn't return something as you might expect given that it is passed to another method. I came accross this while debugging my application which seems to be always selecting PhpRenderer despite this code, so I question whether it even is working at all.

If this example code can be explained, and pointed out how to clean it up or change it, I am willing to spend a minute changing the example to be correct and maybe even explaining it with some inline comments or surrounding commentary.