### PR TITLE
Fix Placeholder view helper return value

### DIFF
--- a/src/Helper/Placeholder.php
+++ b/src/Helper/Placeholder.php
@@ -9,7 +9,6 @@
 
 namespace Zend\View\Helper;
 
-use Zend\View\Exception\InvalidArgumentException;
 use Zend\View\Helper\Placeholder\Container;
 
 /**
@@ -37,15 +36,12 @@ class Placeholder extends AbstractHelper
      * Placeholder helper
      *
      * @param  string $name
-     * @throws InvalidArgumentException
-     * @return Placeholder\Container\AbstractContainer
+     * @return Placeholder\Container\AbstractContainer|Placeholder
      */
     public function __invoke($name = null)
     {
         if ($name === null) {
-            throw new InvalidArgumentException(
-                'Placeholder: missing argument. $name is required by placeholder($name)'
-            );
+            return $this;
         }
 
         $name = (string) $name;

--- a/test/Helper/PlaceholderTest.php
+++ b/test/Helper/PlaceholderTest.php
@@ -71,6 +71,15 @@ class PlaceholderTest extends TestCase
     /**
      * @return void
      */
+    public function testPlaceholderRetrievesItself()
+    {
+        $container = $this->placeholder->__invoke();
+        $this->assertSame($container, $this->placeholder);
+    }
+
+    /**
+     * @return void
+     */
     public function testPlaceholderRetrievesSameContainerOnSubsequentCalls()
     {
         $container1 = $this->placeholder->__invoke('foo');

--- a/test/Helper/PlaceholderTest.php
+++ b/test/Helper/PlaceholderTest.php
@@ -62,6 +62,17 @@ class PlaceholderTest extends TestCase
     /**
      * @return void
      */
+    public function testContainerExists()
+    {
+        $this->placeholder->__invoke('foo');
+        $containerExists = $this->placeholder->__invoke()->containerExists('foo');
+
+        $this->assertTrue($containerExists);
+    }
+
+    /**
+     * @return void
+     */
     public function testPlaceholderRetrievesContainer()
     {
         $container = $this->placeholder->__invoke('foo');

--- a/test/Helper/PlaceholderTest.php
+++ b/test/Helper/PlaceholderTest.php
@@ -97,4 +97,15 @@ class PlaceholderTest extends TestCase
         $container2 = $this->placeholder->__invoke('foo');
         $this->assertSame($container1, $container2);
     }
+
+    /**
+     * @return void
+     */
+    public function testGetContainerRetrievesTheCorrectContainer()
+    {
+        $container1 = $this->placeholder->__invoke('foo');
+        $container2 = $this->placeholder->__invoke()->getContainer('foo');
+
+        $this->assertSame($container1, $container2);
+    }
 }


### PR DESCRIPTION
This PR aims to fix the bug, outlined in the following issue: https://github.com/zendframework/zend-view/issues/16

The changes will allow `$this` as a return value of the view helper, when no name is passed as an argument, thus providing access to the methods inside the view helper. For this reason, more tests have been added to `ZendTest\View\Helper\PlaceholderTest`.
