### PR TITLE
Delete Single or Multiple Containers in Placeholder View Helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,15 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
-- Nothing.
+- [#168](https://github.com/zendframework/zend-view/pull/168) adds two new methods to `Zend\View\Helper\Placeholder` (and thus any
+  helper extending it):
+
+  - `deleteContainer(string $name)` can be used to delete a placeholder container.
+  - `clearContainers()` can be used to clear all placeholder containers.
+
+  These new features are particularly useful when in long-running server
+  environments, such as Swoole, where you may need to clear the contents on each
+  request.
 
 ### Changed
 

--- a/doc/book/helpers/placeholder.md
+++ b/doc/book/helpers/placeholder.md
@@ -63,7 +63,7 @@ $this->placeholder('foo')
 <?= $this->placeholder('foo') ?>
 ```
 
-The above results in an unodered list with pretty indentation.
+The above results in an unordered list with pretty indentation.
 
 Because the `Placeholder` container objects extend `ArrayObject`, you can also
 assign content to a specific key in the container easily, instead of simply
@@ -129,6 +129,21 @@ foreach ($this->data as $datum): ?>
 <?php $this->placeholder('foo')->captureEnd() ?>
 
 <?= $this->placeholder('foo')->data ?>
+```
+
+## Clearing Content
+
+In certain situations it is desirable to remove or clear containers and aggregated content. The placeholder view helper
+provides two methods to either delete a specific container or clear all containers at once:
+
+```php
+<?php
+// Delete a single Container
+$placeholderHelper = $this->plugin('placeholder');
+$placeholderHelper->deleteContainer('myNamedContainer');
+// Clear all containers at once
+$placeholderHelper->clearContainers();
+?>
 ```
 
 ## Concrete Implementations

--- a/doc/book/helpers/placeholder.md
+++ b/doc/book/helpers/placeholder.md
@@ -133,15 +133,18 @@ foreach ($this->data as $datum): ?>
 
 ## Clearing Content
 
-In certain situations it is desirable to remove or clear containers and aggregated content. The placeholder view helper
-provides two methods to either delete a specific container or clear all containers at once:
+In certain situations it is desirable to remove or clear containers and
+aggregated content. The placeholder view helper provides two methods to either
+delete a specific container or clear all containers at once:
 
 ### Delete a single container
+
 ```php
 $this->plugin('placeholder')->deleteContainer('myNamedContainer');
 ```
 
 ### Clear all containers
+
 ```php
 $this->plugin('placeholder')->clearContainers();
 ```

--- a/doc/book/helpers/placeholder.md
+++ b/doc/book/helpers/placeholder.md
@@ -136,14 +136,14 @@ foreach ($this->data as $datum): ?>
 In certain situations it is desirable to remove or clear containers and aggregated content. The placeholder view helper
 provides two methods to either delete a specific container or clear all containers at once:
 
+### Delete a single container
 ```php
-<?php
-// Delete a single Container
-$placeholderHelper = $this->plugin('placeholder');
-$placeholderHelper->deleteContainer('myNamedContainer');
-// Clear all containers at once
-$placeholderHelper->clearContainers();
-?>
+$this->plugin('placeholder')->deleteContainer('myNamedContainer');
+```
+
+### Clear all containers
+```php
+$this->plugin('placeholder')->clearContainers();
 ```
 
 ## Concrete Implementations

--- a/src/Helper/Placeholder.php
+++ b/src/Helper/Placeholder.php
@@ -23,7 +23,7 @@ class Placeholder extends AbstractHelper
     /**
      * Placeholder items
      *
-     * @var array
+     * @var Container\AbstractContainer[]
      */
     protected $items = [];
 
@@ -96,5 +96,29 @@ class Placeholder extends AbstractHelper
         $key = (string) $key;
         $return = array_key_exists($key, $this->items);
         return $return;
+    }
+
+    /**
+     * Delete a specific container by name
+     *
+     * @param string $key
+     * @return self
+     */
+    public function deleteContainer($key)
+    {
+        $key = (string) $key;
+        unset($this->items[$key]);
+        return $this;
+    }
+
+    /**
+     * Remove all containers
+     *
+     * @return self
+     */
+    public function clearContainers()
+    {
+        $this->items = [];
+        return $this;
     }
 }

--- a/src/Helper/Placeholder.php
+++ b/src/Helper/Placeholder.php
@@ -101,24 +101,22 @@ class Placeholder extends AbstractHelper
     /**
      * Delete a specific container by name
      *
-     * @param string $key
-     * @return self
+     * @param  string $key
+     * @return void
      */
     public function deleteContainer($key)
     {
         $key = (string) $key;
         unset($this->items[$key]);
-        return $this;
     }
 
     /**
      * Remove all containers
      *
-     * @return self
+     * @return void
      */
     public function clearContainers()
     {
         $this->items = [];
-        return $this;
     }
 }

--- a/test/Helper/PlaceholderTest.php
+++ b/test/Helper/PlaceholderTest.php
@@ -77,4 +77,29 @@ class PlaceholderTest extends TestCase
         $container2 = $this->placeholder->__invoke('foo');
         $this->assertSame($container1, $container2);
     }
+
+    public function testContainersCanBeDeleted()
+    {
+        $container = $this->placeholder->__invoke('foo');
+        $container->set('Value');
+        $this->assertTrue($this->placeholder->containerExists('foo'));
+        $this->assertSame('Value', (string) $this->placeholder->__invoke('foo'));
+        $this->placeholder->deleteContainer('foo');
+        $this->assertFalse($this->placeholder->containerExists('foo'));
+        $this->assertSame('', (string) $this->placeholder->__invoke('foo'));
+    }
+
+    public function testClearContainersRemovesAllContainers()
+    {
+        $this->placeholder->__invoke('foo');
+        $this->placeholder->__invoke('bar');
+
+        $this->assertTrue($this->placeholder->containerExists('foo'));
+        $this->assertTrue($this->placeholder->containerExists('bar'));
+
+        $this->placeholder->clearContainers();
+
+        $this->assertFalse($this->placeholder->containerExists('foo'));
+        $this->assertFalse($this->placeholder->containerExists('bar'));
+    }
 }


### PR DESCRIPTION
Add the ability to delete single containers or remove all containers from the placeholder view helper. This is useful when you're running with Swoole for example - All _(I Think)_ other placeholder implementations offer a `deleteContainer()` method.