### PR TITLE
zend-json: "^2.6.1 || ^3.0"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "zendframework/zend-eventmanager": "^2.6.2 || ^3.0",
-        "zendframework/zend-json": "^2.6.1",
+        "zendframework/zend-json": "^2.6.1 || ^3.0",
         "zendframework/zend-loader": "^2.5",
         "zendframework/zend-stdlib": "^2.7 || ^3.0"
     },


### PR DESCRIPTION
As I noted in #178 this patch allows zend-json: "^2.6.1 || ^3.0".