### PR TITLE
Fix: replace curly offset access brace with square brackets

### DIFF
--- a/src/Helper/Navigation/Sitemap.php
+++ b/src/Helper/Navigation/Sitemap.php
@@ -267,10 +267,10 @@ class Sitemap extends AbstractHelper
     {
         $href = $page->getHref();
 
-        if (! isset($href{0})) {
+        if (! isset($href[0])) {
             // no href
             return '';
-        } elseif ($href{0} == '/') {
+        } elseif ($href[0] == '/') {
             // href is relative to root; use serverUrl helper
             $url = $this->getServerUrl() . $href;
         } elseif (preg_match('/^[a-z]+:/im', (string) $href)) {


### PR DESCRIPTION
As of PHP 7.4:
the array and string offset access syntax using curly braces is deprecated.