### PR TITLE
Fix for PHP 7.4

### DIFF
--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -239,7 +239,7 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
     public function getVariable($name, $default = null)
     {
         $name = (string) $name;
-        if (array_key_exists($name, $this->variables)) {
+        if (isset($this->variables[$name])) {
             return $this->variables[$name];
         }
 

--- a/src/Model/ViewModel.php
+++ b/src/Model/ViewModel.php
@@ -239,8 +239,13 @@ class ViewModel implements ModelInterface, ClearableModelInterface, RetrievableC
     public function getVariable($name, $default = null)
     {
         $name = (string) $name;
-        if (isset($this->variables[$name])) {
-            return $this->variables[$name];
+
+        if (is_array($this->variables)) {
+            if (array_key_exists($name, $this->variables)) {
+                return $this->variables[$name];
+            }
+        } elseif ($this->variables->offsetExists($name)) {
+            return $this->variables->offsetGet($name);
         }
 
         return $default;

--- a/test/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
+++ b/test/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml
@@ -1,12 +1,12 @@
 <?php
 
-$vars = $this->vars();
+$vars = (array) $this->vars();
 
 if (empty($vars)) {
 	echo "No object model passed";
 } elseif (isset($vars['message'])) {
 	echo $vars['message'];
 } else {
-	$objKey = current($this->vars())->helper->getObjectKey();
+	$objKey = current($vars)->helper->getObjectKey();
 	echo 'This is an iteration with objectKey: ' . $objKey;
 }

--- a/test/Model/ViewModelTest.php
+++ b/test/Model/ViewModelTest.php
@@ -361,4 +361,56 @@ class ViewModelTest extends TestCase
         $this->assertEquals('foo', $model1->getVariable('a'));
         $this->assertEquals('bar', $model2->getVariable('a'));
     }
+
+    public function variableValue()
+    {
+        return [
+            // variables                     default   expected
+
+            // if it is set always get the value
+            [['foo' => 'bar'],                  'baz', 'bar'],
+            [['foo' => 'bar'],                  null,  'bar'],
+            [new ArrayObject(['foo' => 'bar']), 'baz', 'bar'],
+            [new ArrayObject(['foo' => 'bar']), null,  'bar'],
+
+            // if it is null always get null value
+            [['foo' => null],                   null,  null],
+            [['foo' => null],                   'baz', null],
+            [new ArrayObject(['foo' => null]),  null,  null],
+            [new ArrayObject(['foo' => null]),  'baz', null],
+
+            // when it is not set always get default value
+            [[],                                'baz', 'baz'],
+            [new ArrayObject(),                 'baz', 'baz'],
+        ];
+    }
+
+    /**
+     * @dataProvider variableValue
+     *
+     * @param array|ArrayObject $variables
+     * @param string|null $default
+     * @param string|null $expected
+     */
+    public function testGetVariableSetByConstruct($variables, $default, $expected)
+    {
+        $model = new ViewModel($variables);
+
+        self::assertSame($expected, $model->getVariable('foo', $default));
+    }
+
+    /**
+     * @dataProvider variableValue
+     *
+     * @param array|ArrayObject $variables
+     * @param string|null $default
+     * @param string|null $expected
+     */
+    public function testGetVariableSetBySetter($variables, $default, $expected)
+    {
+        $model = new ViewModel();
+        $model->setVariables($variables);
+
+        self::assertSame($expected, $model->getVariable('foo', $default));
+    }
 }


### PR DESCRIPTION
The second commit revels an issue with current code.

`Zend\View\Variable` implements `ArrayObject` but `array_key_exists` doesn't work in this case, as eplained in https://wiki.php.net/rfc/deprecations_php_7_4


This PR is not complete, as with 7.4.0RC3 I still encounter an issue
There were 2 errors:
```

1) ZendTest\View\Helper\PartialLoopTest::testNestedCallsShouldNotOverrideObjectKey
Trying to get property 'helper' of non-object

/dev/shm/BUILD/zend-view-4f5cb653ed4c64bb8d9bf05b294300feb00c67f2/test/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml:10
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Renderer/PhpRenderer.php:506
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/Partial.php:61
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/PartialLoop.php:83
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/PartialLoop.php:61
/dev/shm/BUILD/zend-view-4f5cb653ed4c64bb8d9bf05b294300feb00c67f2/test/Helper/_files/modules/application/views/scripts/partialLoopParentObject.phtml:15
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Renderer/PhpRenderer.php:506
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/Partial.php:61
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/PartialLoop.php:83
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/PartialLoop.php:61
/dev/shm/BUILD/zend-view-4f5cb653ed4c64bb8d9bf05b294300feb00c67f2/test/Helper/PartialLoopTest.php:329

2) ZendTest\View\Helper\PartialLoopTest::testNestedCallsShouldNotOverrideObjectKeyInLoopMethod
Trying to get property 'helper' of non-object

/dev/shm/BUILD/zend-view-4f5cb653ed4c64bb8d9bf05b294300feb00c67f2/test/Helper/_files/modules/application/views/scripts/partialLoopChildObject.phtml:10
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Renderer/PhpRenderer.php:506
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/Partial.php:61
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/PartialLoop.php:83
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/PartialLoop.php:61
/dev/shm/BUILD/zend-view-4f5cb653ed4c64bb8d9bf05b294300feb00c67f2/test/Helper/_files/modules/application/views/scripts/partialLoopParentObject.phtml:15
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Renderer/PhpRenderer.php:506
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/Partial.php:61
/dev/shm/BUILDROOT/php-zendframework-zend-view-2.11.2-1.fc29.remi.x86_64/usr/share/php/Zend/View/Helper/PartialLoop.php:83
/dev/shm/BUILD/zend-view-4f5cb653ed4c64bb8d9bf05b294300feb00c67f2/test/Helper/PartialLoopTest.php:640

```