### PR TITLE
Hotfix: use short array notation in the documentation

### DIFF
--- a/docs/book/helpers/cycle.md
+++ b/docs/book/helpers/cycle.md
@@ -64,7 +64,7 @@ The output of the two previous examples combined becomes:
 
 If you are nesting cycles, you must provide all but one of them with a name; do
 this by providing a second parameter to the `cycle()` invocation:
-`$this->cycle(array('odd', 'even'), 'cycle2')`
+`$this->cycle(['odd', 'even'], 'cycle2')`
 
 ```php
 <table>

--- a/docs/book/helpers/flash-messenger.md
+++ b/docs/book/helpers/flash-messenger.md
@@ -105,10 +105,10 @@ $flash->setMessageOpenFormat('<div%s>
     ->setMessageSeparatorString('</li><li>')
     ->setMessageCloseString('</li></ul></div>');
 
-echo $flash->render('error',   array('alert', 'alert-dismissible', 'alert-danger'));
-echo $flash->render('info',    array('alert', 'alert-dismissible', 'alert-info'));
-echo $flash->render('default', array('alert', 'alert-dismissible', 'alert-warning'));
-echo $flash->render('success', array('alert', 'alert-dismissible', 'alert-success'));
+echo $flash->render('error',   ['alert', 'alert-dismissible', 'alert-danger']);
+echo $flash->render('info',    ['alert', 'alert-dismissible', 'alert-info']);
+echo $flash->render('default', ['alert', 'alert-dismissible', 'alert-warning']);
+echo $flash->render('success', ['alert', 'alert-dismissible', 'alert-success']);
 ```
 
 The output of the above example would create dismissable `FlashMessages` with

--- a/docs/book/helpers/head-meta.md
+++ b/docs/book/helpers/head-meta.md
@@ -44,7 +44,7 @@ optional associative array that can contain keys for `lang` and/or `scheme`.
 
 You may also set meta tags using the `headMeta()` helper method, which has the
 following signature: `headMeta($content, $keyValue, $keyType = 'name',
-$modifiers = array(), $placement = 'APPEND')`.  `$keyValue` is the content for
+$modifiers = [], $placement = 'APPEND')`.  `$keyValue` is the content for
 the key specified in `$keyType`, which should be either `name` or `http-equiv`.
 `$keyType` may also be specified as `property` if the doctype has been set to
 `XHTML1_RDFA`. `$placement` can be `SET` (overwrites all previously stored

--- a/docs/book/helpers/head-style.md
+++ b/docs/book/helpers/head-style.md
@@ -39,7 +39,7 @@ The usage for this will be showed in an example below.
 
 Finally, you can also use the `headStyle()` method to quickly add declarations
 elements; the signature for this is `headStyle($content = null, $placement =
-'APPEND', $attributes = array())`.  `$placement` should be either `APPEND`,
+'APPEND', $attributes = [])`.  `$placement` should be either `APPEND`,
 `PREPEND`, or `SET`.
 
 `HeadStyle` overrides each of `append()`, `offsetSet()`, `prepend()`, and

--- a/docs/book/php-renderer.md
+++ b/docs/book/php-renderer.md
@@ -109,7 +109,7 @@ inject some variables. This can be done in 4 different ways.
 
 - Pass an associative array (or `ArrayAccess` instance, or `Zend\View\Variables`
   instance) of items as the second argument to `render()`:
-  `$renderer->render($templateName, array('foo' =&gt; 'bar))`
+  `$renderer->render($templateName, ['foo' => 'bar'])`
 - Assign a `Zend\View\Variables` instance, associative array, or `ArrayAccess`
   instance to the `setVars()` method.
 - Assign variables as instance properties of the renderer: `$renderer->foo =


### PR DESCRIPTION
- [x] Is this related to documentation?
  <!-- Is it a typographical and/or grammatical fix? -->
  <!-- Is it new documentation? -->
