### PR TITLE
[WIP] Broaden HTTPS Check

### DIFF
--- a/src/Helper/ServerUrl.php
+++ b/src/Helper/ServerUrl.php
@@ -144,9 +144,8 @@ class ServerUrl extends AbstractHelper
         }
 
         switch (true) {
-            case (isset($_SERVER['HTTPS']) && ($_SERVER['HTTPS'] == 'on' || $_SERVER['HTTPS'] === true)):
-            case (isset($_SERVER['HTTP_SCHEME']) && ($_SERVER['HTTP_SCHEME'] == 'https')):
-            case (443 === $this->getPort()):
+            case (isset($_SERVER['HTTPS']) && (strtolower($_SERVER['HTTPS']) == 'on' || $_SERVER['HTTPS'] === true)):
+            case (isset($_SERVER['HTTP_SCHEME']) && (strtolower($_SERVER['HTTP_SCHEME']) == 'https')):
             case $this->isReversedProxy():
                 $scheme = 'https';
                 break;


### PR DESCRIPTION
Because:
- It is common for end users to use ports other than 443 for HTTPS
- Mature systems, like IBM i, like to uppercase values

Provide a narrative description of what you are trying to accomplish:

- [x] Are you fixing a bug?
  - [x] Detail how the bug is invoked currently.
    If you try building an API with HTTPS without using 443, the self links that are built and returned will be HTTP. If you try building an API on IBM i, even using 443, it will still send HTTP, because IBM i will uppercase `ON` and `HTTPS` values for the SERVER properties.
  - [x] Detail the original, incorrect behavior.
    As stated above, the self links that are generated in API responses will be HTTP instead of HTTPS.
  - [x] Detail the new, expected behavior.
    Self links will properly send HTTPS.
  - [x] Base your feature on the `master` branch, and submit against that branch.
  - [ ] Add a regression test that demonstrates the bug, and proves the fix.
    This is difficult to accomplish, as the test I am doing runs on IBM i.
  - [ ] Add a `CHANGELOG.md` entry for the fix.
    TODO
